### PR TITLE
Slow queries retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ An [MCP](https://modelcontextprotocol.io/) server implementation of Couchbase th
 - Run a [SQL++ query](https://www.couchbase.com/sqlplusplus/) on a specified bucket and scope
   - There is an option in the MCP server, `READ_ONLY_QUERY_MODE` that is set to true by default to disable running SQL++ queries that change the data or the underlying collection structure. Note that the documents can still be updated by ID.
 - Retreive Index Advisor advice for a query on a specified bucket and scope.
+- Get summary and specific information on slow running queries from the completed_requests catalog.
 
 ## Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -6,11 +6,12 @@ An [MCP](https://modelcontextprotocol.io/) server implementation of Couchbase th
 
 - Get a list of all the scopes and collections in the specified bucket
 - Get the structure for a collection
-- Get a document by ID from a specified scope and collection
-- Upsert a document by ID to a specified scope and collection
-- Delete a document by ID from a specified scope and collection
-- Run a [SQL++ query](https://www.couchbase.com/sqlplusplus/) on a specified scope
+- Get a document by ID from a specified bucket, scope and collection
+- Upsert a document by ID to a specified bucket, scope and collection
+- Delete a document by ID from a specified bucket, scope and collection
+- Run a [SQL++ query](https://www.couchbase.com/sqlplusplus/) on a specified bucket and scope
   - There is an option in the MCP server, `READ_ONLY_QUERY_MODE` that is set to true by default to disable running SQL++ queries that change the data or the underlying collection structure. Note that the documents can still be updated by ID.
+- Retreive Index Advisor advice for a query on a specified bucket and scope.
 
 ## Prerequisites
 
@@ -46,7 +47,6 @@ This is the common configuration for the MCP clients such as Claude Desktop, Cur
         "CB_CONNECTION_STRING": "couchbases://connection-string",
         "CB_USERNAME": "username",
         "CB_PASSWORD": "password",
-        "CB_BUCKET_NAME": "bucket_name"
       }
     }
   }
@@ -58,7 +58,6 @@ The server can be configured using environment variables. The following variable
 - `CB_CONNECTION_STRING`: The connection string to the Couchbase cluster
 - `CB_USERNAME`: The username with access to the bucket to use to connect
 - `CB_PASSWORD`: The password for the username to connect
-- `CB_BUCKET_NAME`: The name of the bucket that the server will access
 - `READ_ONLY_QUERY_MODE`: Setting to configure whether SQL++ queries that allow data to be modified are allowed. It is set to True by default.
 - `path/to/cloned/repo/mcp-server-couchbase/` should be the path to the cloned repository on your local machine. Don't forget the trailing slash at the end!
 
@@ -138,7 +137,7 @@ There is an option to run the MCP server in [Server-Sent Events (SSE)](https://m
 
 By default, the MCP server will run on port 8080 but this can be configured using the `FASTMCP_PORT` environment variable.
 
-> uv run src/mcp_server.py --connection-string='<couchbase_connection_string>' --username='<database_username>' --password='<database_password>' --bucket-name='<couchbase_bucket_to_use>' --read-only-query-mode=true --transport=sse
+> uv run src/mcp_server.py --connection-string='<couchbase_connection_string>' --username='<database_username>' --password='<database_password>' --read-only-query-mode=true --transport=sse
 
 The server will be available on http://localhost:8080/sse. This can be used in MCP clients supporting SSE transport mode.
 
@@ -159,7 +158,6 @@ docker run -i \
   -e CB_CONNECTION_STRING='<couchbase_connection_string>' \
   -e CB_USERNAME='<database_user>' \
   -e CB_PASSWORD='<database_password>' \
-  -e CB_BUCKET_NAME='<bucket_name>' \
   -e MCP_TRANSPORT='stdio/sse' \
   -e READ_ONLY_QUERY_MODE="true/false" \
   mcp/couchbase

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -336,6 +336,72 @@ def run_sql_plus_plus_query(
         logger.error(f"Error running query: {str(e)}", exc_info=True)
         raise
 
+#Slow Query tools
+
+@mcp.tool()
+def aggregate_slow_queries_stats_by_pattern(ctx: Context, query_limit:int ) -> list[dict[str, Any]]:
+    """Run a query on the completed_requests system catalog to discover potential slow running queries. 
+    This query attempts to reduce the statements of logged queries into patterns by removing any values and only looking at the query structure with regard to returned fields,
+    filtered predicates, sorts and aggregations. For each query pattern it returns the count, min, max and average duration.
+    Accepts an integer as a limit to the number of results returned.
+    Returns an array of query patterns with the count, min, max and average duration ordered from most to least found patterns.
+    """
+
+    query_template = """
+    SELECT query_pattern,
+        COUNT(*) AS count,
+        MIN(STR_TO_DURATION(serviceTime))/1000000000 AS min_duration_in_seconds,
+        MAX(STR_TO_DURATION(serviceTime))/1000000000 AS max_duration_in_seconds,
+        AVG(STR_TO_DURATION(serviceTime))/1000000000 AS avg_duration_in_seconds
+    FROM system:completed_requests
+    LET query_pattern = IFMISSING(preparedText, REGEX_REPLACE(
+    REGEX_REPLACE(
+    REGEX_REPLACE(
+    REGEX_REPLACE(
+    REGEX_REPLACE(
+    REGEX_REPLACE(statement,
+        "\\\\s+", " "),
+        '"(?:[^"]|"")*"', "?"),
+        "'(?:[^']|'')*'", "?"),
+        "\\\\b-?\\\\d+\\\\.?\\\\d*\\\\b", "?"),
+        "(?i)\\\\b(NULL|TRUE|FALSE)\\\\b", "?"),
+        "(\\\\?\\\\s*,\\\\s*)+\\\\?", "?"))
+    WHERE UPPER(IFMISSING(preparedText, statement)) NOT LIKE 'INFER %'
+        AND UPPER(IFMISSING(preparedText, statement)) NOT LIKE 'ADVISE %'
+        AND UPPER(IFMISSING(preparedText, statement)) NOT LIKE 'CREATE %'
+        AND UPPER(IFMISSING(preparedText, statement)) NOT LIKE 'CREATE INDEX%'
+        AND UPPER(IFMISSING(preparedText, statement)) NOT LIKE 'ALTER INDEX%'
+        AND UPPER(IFMISSING(preparedText, statement)) NOT LIKE '% SYSTEM:%'
+    GROUP BY query_pattern
+    ORDER BY count DESC
+    LIMIT {limit}
+    """
+
+    query = query_template.format(limit=query_limit)
+    try:
+        result = system_catalog_query(ctx,query)
+        return result
+    except Exception as e:
+        logger.error(f"Error completed_request query: {str(e)}", exc_info=True)
+        raise e
+
+
+
+# Util Functions
+def system_catalog_query(ctx: Context, query: str) -> list[dict[str, Any]]:
+    cluster = ctx.request_context.lifespan_context.cluster
+    try:
+
+        results = []
+        result = cluster.query(query)
+        for row in result:
+            results.append(row)
+        return results
+    except Exception as e:
+        logger.error(f"Error running query: {str(e)}", exc_info=True)
+        raise e
+
+
 
 if __name__ == "__main__":
     main()

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -275,13 +275,14 @@ def advise_index_for_sql_plus_plus_query(
     try:
         query = f"ADVISE {query}"
         result = run_sql_plus_plus_query(ctx, bucket_name, scope_name, query)
-        advice = result[0].get("advice")
-        if (advice is not None):
-            advise_info = advice.get("adviseinfo")
-            if ( advise_info is not None):
-                response["current_indexes"] = advise_info.get("current_indexes", "No current indexes")
-                response["recommended_indexes"] = advise_info.get("recommended_indexes","No index recommendations available")
-                response["query"]=result[0].get("query","Query statement unavailable")
+
+        if result and (advice := result[0].get("advice")):
+            if (advice is not None):
+                advise_info = advice.get("adviseinfo")
+                if ( advise_info is not None):
+                    response["current_indexes"] = advise_info.get("current_indexes", "No current indexes")
+                    response["recommended_indexes"] = advise_info.get("recommended_indexes","No index recommendations available")
+                    response["query"]=result[0].get("query","Query statement unavailable")
         return response
     except Exception as e:
         logger.error(f"Error running Advise on query: {e}")

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -26,7 +26,6 @@ class AppContext:
     """Context for the MCP server."""
 
     cluster: Cluster | None = None
-    #bucket: Any | None = None
     read_only_query_mode: bool = True
 
 
@@ -64,12 +63,7 @@ def get_settings() -> dict:
     help="Couchbase database password",
     callback=validate_required_param,
 )
-#@click.option(
-#    "--bucket-name",
-#    envvar="CB_BUCKET_NAME",
-#    help="Couchbase bucket name",
-#    callback=validate_required_param,
-#)
+
 @click.option(
     "--read-only-query-mode",
     envvar="READ_ONLY_QUERY_MODE",
@@ -90,7 +84,6 @@ def main(
     connection_string,
     username,
     password,
-    #bucket_name,
     read_only_query_mode,
     transport,
 ):
@@ -99,7 +92,6 @@ def main(
         "connection_string": connection_string,
         "username": username,
         "password": password,
-        #"bucket_name": bucket_name,
         "read_only_query_mode": read_only_query_mode,
     }
     mcp.run(transport=transport)
@@ -114,7 +106,6 @@ async def app_lifespan(server: FastMCP) -> AsyncIterator[AppContext]:
     connection_string = settings.get("connection_string")
     username = settings.get("username")
     password = settings.get("password")
-    #bucket_name = settings.get("bucket_name")
     read_only_query_mode = settings.get("read_only_query_mode")
 
     # Validate configuration
@@ -128,9 +119,7 @@ async def app_lifespan(server: FastMCP) -> AsyncIterator[AppContext]:
     if not password:
         logger.error("Couchbase database password is not set")
         missing_vars.append("password")
-    #if not bucket_name:
-    #    logger.error("Couchbase bucket name is not set")
-    #    missing_vars.append("bucket_name")
+
 
     if missing_vars:
         error_msg = f"Missing required configuration: {', '.join(missing_vars)}"
@@ -148,10 +137,8 @@ async def app_lifespan(server: FastMCP) -> AsyncIterator[AppContext]:
         cluster.wait_until_ready(timedelta(seconds=5))
         logger.info("Successfully connected to Couchbase cluster")
 
-        #bucket = cluster.bucket(bucket_name)
         yield AppContext(
             cluster=cluster, 
-            #bucket=bucket,
             read_only_query_mode=read_only_query_mode
         )
 
@@ -170,7 +157,6 @@ def get_scopes_and_collections_in_bucket(ctx: Context, bucket_name: str) -> dict
     """Get the names of all scopes and collections for a specified bucket.
     Returns a dictionary with scope names as keys and lists of collection names as values.
     """
-    #bucket = ctx.request_context.lifespan_context.bucket
     cluster = ctx.request_context.lifespan_context.cluster
 
     try:
@@ -212,7 +198,6 @@ def get_document_by_id(
     ctx: Context, bucket_name: str, scope_name: str, collection_name: str, document_id: str
 ) -> dict[str, Any]:
     """Get a document by its ID from the specified bucket, scope and collection."""
-    #bucket = ctx.request_context.lifespan_context.bucket
     cluster = ctx.request_context.lifespan_context.cluster
     try:
         bucket = cluster.bucket(bucket_name)
@@ -239,7 +224,6 @@ def upsert_document_by_id(
 ) -> bool:
     """Insert or update a document in a bucket, scope and collection by its ID.
     Returns True on success, False on failure."""
-    #bucket = ctx.request_context.lifespan_context.bucket
     cluster = ctx.request_context.lifespan_context.cluster
     try:
         bucket = cluster.bucket(bucket_name)
@@ -262,7 +246,6 @@ def delete_document_by_id(
 ) -> bool:
     """Delete a document in a bucket, scope and collection by its ID.
     Returns True on success, False on failure."""
-    #bucket = ctx.request_context.lifespan_context.bucket
     cluster = ctx.request_context.lifespan_context.cluster
     try:
         bucket = cluster.bucket(bucket_name)
@@ -309,7 +292,6 @@ def run_sql_plus_plus_query(
     ctx: Context, bucket_name: str, scope_name: str, query: str
 ) -> list[dict[str, Any]]:
     """Run a SQL++ query on a scope in a specified bucket and return the results as a list of JSON objects."""
-    #bucket = ctx.request_context.lifespan_context.bucket
     cluster = ctx.request_context.lifespan_context.cluster
     try:
         bucket = cluster.bucket(bucket_name)


### PR DESCRIPTION
Adding the capability to query the completed_requests catalog for slow queries.
Two methods added:
1. Return an aggregate summary of slow queries in the cluster with timings grouped by query pattern
2. Return the query plan for a specified query.