### PR TITLE
Adding mTLS support 

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,12 @@ An [MCP](https://modelcontextprotocol.io/) server implementation of Couchbase th
 
 - Get a list of all the scopes and collections in the specified bucket
 - Get the structure for a collection
-- Get a document by ID from a specified scope and collection
-- Upsert a document by ID to a specified scope and collection
-- Delete a document by ID from a specified scope and collection
-- Run a [SQL++ query](https://www.couchbase.com/sqlplusplus/) on a specified scope
+- Get a document by ID from a specified bucket, scope and collection
+- Upsert a document by ID to a specified bucket, scope and collection
+- Delete a document by ID from a specified bucket, scope and collection
+- Run a [SQL++ query](https://www.couchbase.com/sqlplusplus/) on a specified bucket and scope
   - There is an option in the MCP server, `READ_ONLY_QUERY_MODE` that is set to true by default to disable running SQL++ queries that change the data or the underlying collection structure. Note that the documents can still be updated by ID.
+- Retreive Index Advisor advice for a query on a specified bucket and scope.
 
 ## Prerequisites
 
@@ -46,7 +47,6 @@ This is the common configuration for the MCP clients such as Claude Desktop, Cur
         "CB_CONNECTION_STRING": "couchbases://connection-string",
         "CB_USERNAME": "username",
         "CB_PASSWORD": "password",
-        "CB_BUCKET_NAME": "bucket_name"
       }
     }
   }
@@ -58,7 +58,6 @@ The server can be configured using environment variables. The following variable
 - `CB_CONNECTION_STRING`: The connection string to the Couchbase cluster
 - `CB_USERNAME`: The username with access to the bucket to use to connect
 - `CB_PASSWORD`: The password for the username to connect
-- `CB_BUCKET_NAME`: The name of the bucket that the server will access
 - `READ_ONLY_QUERY_MODE`: Setting to configure whether SQL++ queries that allow data to be modified are allowed. It is set to True by default.
 - `path/to/cloned/repo/mcp-server-couchbase/` should be the path to the cloned repository on your local machine. Don't forget the trailing slash at the end!
 
@@ -138,7 +137,7 @@ There is an option to run the MCP server in [Server-Sent Events (SSE)](https://m
 
 By default, the MCP server will run on port 8080 but this can be configured using the `FASTMCP_PORT` environment variable.
 
-> uv run src/mcp_server.py --connection-string='<couchbase_connection_string>' --username='<database_username>' --password='<database_password>' --bucket-name='<couchbase_bucket_to_use>' --read-only-query-mode=true --transport=sse
+> uv run src/mcp_server.py --connection-string='<couchbase_connection_string>' --username='<database_username>' --password='<database_password>' --read-only-query-mode=true --transport=sse
 
 The server will be available on http://localhost:8080/sse. This can be used in MCP clients supporting SSE transport mode.
 
@@ -159,7 +158,6 @@ docker run -i \
   -e CB_CONNECTION_STRING='<couchbase_connection_string>' \
   -e CB_USERNAME='<database_user>' \
   -e CB_PASSWORD='<database_password>' \
-  -e CB_BUCKET_NAME='<bucket_name>' \
   -e MCP_TRANSPORT='stdio/sse' \
   -e READ_ONLY_QUERY_MODE="true/false" \
   mcp/couchbase

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ An [MCP](https://modelcontextprotocol.io/) server implementation of Couchbase th
   - There is an option in the MCP server, `READ_ONLY_QUERY_MODE` that is set to true by default to disable running SQL++ queries that change the data or the underlying collection structure. Note that the documents can still be updated by ID.
 - Retreive Index Advisor advice for a query on a specified bucket and scope.
 
+
 ## Prerequisites
 
 - Python 3.10 or higher.
@@ -31,7 +32,7 @@ git clone https://github.com/Couchbase-Ecosystem/mcp-server-couchbase.git
 ### Server Configuration for MCP Clients
 
 This is the common configuration for the MCP clients such as Claude Desktop, Cursor, Windsurf Editor.
-
+Using Basic Auth:
 ```json
 {
   "mcpServers": {
@@ -47,6 +48,30 @@ This is the common configuration for the MCP clients such as Claude Desktop, Cur
         "CB_CONNECTION_STRING": "couchbases://connection-string",
         "CB_USERNAME": "username",
         "CB_PASSWORD": "password",
+        "CA_CERT_PATH" : "path/to/ca.crt"
+      }
+    }
+  }
+}
+```
+
+Using mTLS:
+
+```json
+{
+  "mcpServers": {
+    "couchbase": {
+      "command": "uv",
+      "args": [
+        "--directory",
+        "path/to/cloned/repo/mcp-server-couchbase/",
+        "run",
+        "src/mcp_server.py"
+      ],
+      "env": {
+        "CB_CONNECTION_STRING": "couchbases://connection-string",
+        "CLIENT_CERT_PATH": "path/to/client/cert_and_key/",
+        "CA_CERT_PATH" : "path/to/ca.crt"
       }
     }
   }
@@ -56,8 +81,10 @@ This is the common configuration for the MCP clients such as Claude Desktop, Cur
 The server can be configured using environment variables. The following variables are supported:
 
 - `CB_CONNECTION_STRING`: The connection string to the Couchbase cluster
-- `CB_USERNAME`: The username with access to the bucket to use to connect
-- `CB_PASSWORD`: The password for the username to connect
+- `CB_USERNAME`: The username with access to the bucket to use to connect. Must be set if using Baisc Auth and unset if using mTLS.
+- `CB_PASSWORD`: The password for the username to connect. Must be set if using Baisc Auth and unset if using mTLS with client certificate.
+- `CLIENT_CERT_PATH`: The path to client certificate (named client.pem) and key (named client.key) for mTLS authentication. Must be set if using mTLS and unset if using Basic Auth with username and password. 
+- `CA_CERT_PATH`: The path to the CA certificate for trusted TLS connection to the server. If not provided, locally trusted certificate store will be used.
 - `READ_ONLY_QUERY_MODE`: Setting to configure whether SQL++ queries that allow data to be modified are allowed. It is set to True by default.
 - `path/to/cloned/repo/mcp-server-couchbase/` should be the path to the cloned repository on your local machine. Don't forget the trailing slash at the end!
 

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -151,7 +151,29 @@ async def app_lifespan(server: FastMCP) -> AsyncIterator[AppContext]:
 mcp = FastMCP(MCP_SERVER_NAME, lifespan=app_lifespan)
 
 
+
 # Tools
+
+@mcp.tool()
+def get_list_of_buckets_with_settings(
+    ctx: Context
+) -> list[str]:
+    """Get the list of buckets from the Couchbase cluster, including their bucket settings.
+    Returns a list of bucket setting objects.
+    """
+    cluster = ctx.request_context.lifespan_context.cluster
+    result=[]
+    try:
+        bucket_manager = cluster.buckets()
+        buckets = bucket_manager.get_all_buckets()
+        for b in buckets:
+            result.append(b)
+        return result
+    except Exception as e:
+        logger.error(f"Error getting bucket names: {e}")
+        raise e
+
+
 @mcp.tool()
 def get_scopes_and_collections_in_bucket(ctx: Context, bucket_name: str) -> dict[str, list[str]]:
     """Get the names of all scopes and collections for a specified bucket.

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -186,35 +186,19 @@ async def app_lifespan(server: FastMCP) -> AsyncIterator[AppContext]:
         protocol = connection_string.split("://", 1)[0]
         use_tls = (protocol[-1] == 's')
 
-    # Validate configuration
-    missing_vars = []
-    if not connection_string:
-        logger.error("Couchbase connection string is not set")
-        missing_vars.append("connection_string")
-    if not username:
-        logger.error("Couchbase database user is not set")
-        missing_vars.append("username")
-    if not password:
-        logger.error("Couchbase database password is not set")
-        missing_vars.append("password")
-
-
-    if missing_vars:
-        error_msg = f"Missing required configuration: {', '.join(missing_vars)}"
-        logger.error(error_msg)
-        raise ValueError(error_msg)
 
     try:
         logger.info("Creating Couchbase cluster connection...")
         #use client cert if provided, else user/password
         if client_cert_path:
+            client_cert_path = client_cert_path[:-1] if client_cert_path.endswith('/') else client_cert_path
             tls_conf = {
                 "cert_path" : f'{client_cert_path}/client.pem',
                 "key_path" : f'{client_cert_path}/client.key',
             }
             #set ca cert as trust store if provided
             if ca_cert_path:
-                tls_conf["trust_store"] = ca_cert_path
+                tls_conf["trust_store_path"] = ca_cert_path
             auth = CertificateAuthenticator(**tls_conf)
         else:
             auth = PasswordAuthenticator(username, password)

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 from typing import Any
 from mcp.server.fastmcp import FastMCP, Context
 from couchbase.cluster import Cluster
-from couchbase.auth import PasswordAuthenticator
+from couchbase.auth import PasswordAuthenticator, CertificateAuthenticator
 from couchbase.options import ClusterOptions
 import logging
 from dataclasses import dataclass
@@ -10,6 +10,7 @@ from contextlib import asynccontextmanager
 from typing import AsyncIterator
 from lark_sqlpp import modifies_data, modifies_structure, parse_sqlpp
 import click
+import os
 
 MCP_SERVER_NAME = "couchbase"
 
@@ -27,6 +28,12 @@ class AppContext:
 
     cluster: Cluster | None = None
     read_only_query_mode: bool = True
+    username: str = None
+    password: str = None
+    connection_string: str = None
+    ca_cert_path : str = None
+    use_tls : bool = True
+    client_cert_path : str = None
 
 
 def validate_required_param(
@@ -36,6 +43,47 @@ def validate_required_param(
     if not value or value.strip() == "":
         raise click.BadParameter(f"{param.name} cannot be empty")
     return value
+
+def validate_authentication_method(params : dict ) -> bool:
+    """Util function to verify either user/password combination OR client certificates have been included"""
+    username = params.get("username")
+    password = params.get("password")
+    client_cert_path = params.get("client_cert_path")
+    ca_cert_path = params.get("ca_cert_path")
+
+    # Strip values to check for empty strings
+    if username is not None:
+        username = username.strip()
+    if password is not None:
+        password = password.strip()
+
+    if client_cert_path:
+        client_cert = os.path.join(client_cert_path, "client.pem")
+        client_key = os.path.join(client_cert_path, "client.key")
+
+        if not os.path.isfile(client_cert) or not os.path.isfile(client_key):
+            raise click.BadParameter(
+                f"Client certificate files not found in {client_cert_path}. Required: client.pem and client.key."
+            )
+
+        if username or password:
+            raise click.BadParameter(
+                "You must use either a client certificate or username/password, not both."
+            )
+
+    elif username or password:
+        if not username or not password:
+            raise click.BadParameter(
+                "Both username and password must be provided and non-empty if using basic authentication."
+            )
+    else:
+        raise click.BadParameter(
+            "You must provide either a client certificate path or username/password combination, neither received."
+        )
+
+    if not ca_cert_path:
+        logger.warning(f"A trusted CA certificate has not been provided, using local trust store for TLS connections")
+
 
 
 def get_settings() -> dict:
@@ -55,13 +103,28 @@ def get_settings() -> dict:
     "--username",
     envvar="CB_USERNAME",
     help="Couchbase database user",
-    callback=validate_required_param,
+    #callback=validate_required_param,
 )
 @click.option(
     "--password",
     envvar="CB_PASSWORD",
     help="Couchbase database password",
-    callback=validate_required_param,
+    #callback=validate_required_param,
+)
+
+@click.option(
+    '--ca-cert-path',
+    envvar="CA_CERT_PATH",
+    type=click.Path(exists=True),
+    default=None,
+    help='Path to Server TLS certificate, required for API calls.')
+
+@click.option(
+    "--client-cert-path",
+    envvar="CLIENT_CERT_PATH",
+    default=None,
+    help="Path to client.key and client.pem files for mtls client authentication",
+    #callback=validate_required_param,
 )
 
 @click.option(
@@ -85,6 +148,8 @@ def main(
     username,
     password,
     read_only_query_mode,
+    ca_cert_path,
+    client_cert_path,
     transport,
 ):
     """Couchbase MCP Server"""
@@ -93,7 +158,14 @@ def main(
         "username": username,
         "password": password,
         "read_only_query_mode": read_only_query_mode,
+        "ca_cert_path" : ca_cert_path,
+        "client_cert_path" : client_cert_path
     }
+    try:
+        validate_authentication_method(ctx.obj)
+    except Exception as e:
+        logger.error(f"Failed to validate auth method params: {e}")
+        raise e
     mcp.run(transport=transport)
 
 
@@ -107,6 +179,12 @@ async def app_lifespan(server: FastMCP) -> AsyncIterator[AppContext]:
     username = settings.get("username")
     password = settings.get("password")
     read_only_query_mode = settings.get("read_only_query_mode")
+    ca_cert_path = settings.get("ca_cert_path")
+    client_cert_path = settings.get("client_cert_path")
+    use_tls = True
+    if "://" in connection_string:
+        protocol = connection_string.split("://", 1)[0]
+        use_tls = (protocol[-1] == 's')
 
     # Validate configuration
     missing_vars = []
@@ -128,7 +206,18 @@ async def app_lifespan(server: FastMCP) -> AsyncIterator[AppContext]:
 
     try:
         logger.info("Creating Couchbase cluster connection...")
-        auth = PasswordAuthenticator(username, password)
+        #use client cert if provided, else user/password
+        if client_cert_path:
+            tls_conf = {
+                "cert_path" : f'{client_cert_path}/client.pem',
+                "key_path" : f'{client_cert_path}/client.key',
+            }
+            #set ca cert as trust store if provided
+            if ca_cert_path:
+                tls_conf["trust_store"] = ca_cert_path
+            auth = CertificateAuthenticator(**tls_conf)
+        else:
+            auth = PasswordAuthenticator(username, password)
 
         options = ClusterOptions(auth)
         options.apply_profile("wan_development")
@@ -139,7 +228,13 @@ async def app_lifespan(server: FastMCP) -> AsyncIterator[AppContext]:
 
         yield AppContext(
             cluster=cluster, 
-            read_only_query_mode=read_only_query_mode
+            ca_cert_path = ca_cert_path,
+            connection_string = connection_string,
+            username=username,
+            password=password,
+            read_only_query_mode=read_only_query_mode,
+            use_tls=use_tls,
+            client_cert_path=client_cert_path
         )
 
     except Exception as e:

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -275,13 +275,14 @@ def advise_index_for_sql_plus_plus_query(
     try:
         query = f"ADVISE {query}"
         result = run_sql_plus_plus_query(ctx, bucket_name, scope_name, query)
-        advice = result[0].get("advice")
-        if (advice is not None):
-            advise_info = advice.get("adviseinfo")
-            if ( advise_info is not None):
-                response["current_indexes"] = advise_info.get("current_indexes", "No current indexes")
-                response["recommended_indexes"] = advise_info.get("recommended_indexes","No index recommendations available")
-                response["query"]=result[0].get("query","Query statement unavailable")
+
+        if result and (advice := result[0].get("advice")):
+            if (advice is not None):
+                advise_info = advice.get("adviseinfo")
+                if ( advise_info is not None):
+                    response["current_indexes"] = advise_info.get("current_indexes", "No current indexes")
+                    response["recommended_indexes"] = advise_info.get("recommended_indexes","No index recommendations available")
+                    response["query"]=result[0].get("query","Query statement unavailable")
         return response
     except Exception as e:
         logger.error(f"Error running Advise on query: {e}")

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -26,7 +26,6 @@ class AppContext:
     """Context for the MCP server."""
 
     cluster: Cluster | None = None
-    #bucket: Any | None = None
     read_only_query_mode: bool = True
 
 
@@ -64,12 +63,7 @@ def get_settings() -> dict:
     help="Couchbase database password",
     callback=validate_required_param,
 )
-#@click.option(
-#    "--bucket-name",
-#    envvar="CB_BUCKET_NAME",
-#    help="Couchbase bucket name",
-#    callback=validate_required_param,
-#)
+
 @click.option(
     "--read-only-query-mode",
     envvar="READ_ONLY_QUERY_MODE",
@@ -90,7 +84,6 @@ def main(
     connection_string,
     username,
     password,
-    #bucket_name,
     read_only_query_mode,
     transport,
 ):
@@ -99,7 +92,6 @@ def main(
         "connection_string": connection_string,
         "username": username,
         "password": password,
-        #"bucket_name": bucket_name,
         "read_only_query_mode": read_only_query_mode,
     }
     mcp.run(transport=transport)
@@ -114,7 +106,6 @@ async def app_lifespan(server: FastMCP) -> AsyncIterator[AppContext]:
     connection_string = settings.get("connection_string")
     username = settings.get("username")
     password = settings.get("password")
-    #bucket_name = settings.get("bucket_name")
     read_only_query_mode = settings.get("read_only_query_mode")
 
     # Validate configuration
@@ -128,9 +119,7 @@ async def app_lifespan(server: FastMCP) -> AsyncIterator[AppContext]:
     if not password:
         logger.error("Couchbase database password is not set")
         missing_vars.append("password")
-    #if not bucket_name:
-    #    logger.error("Couchbase bucket name is not set")
-    #    missing_vars.append("bucket_name")
+
 
     if missing_vars:
         error_msg = f"Missing required configuration: {', '.join(missing_vars)}"
@@ -148,10 +137,8 @@ async def app_lifespan(server: FastMCP) -> AsyncIterator[AppContext]:
         cluster.wait_until_ready(timedelta(seconds=5))
         logger.info("Successfully connected to Couchbase cluster")
 
-        #bucket = cluster.bucket(bucket_name)
         yield AppContext(
             cluster=cluster, 
-            #bucket=bucket,
             read_only_query_mode=read_only_query_mode
         )
 
@@ -170,7 +157,6 @@ def get_scopes_and_collections_in_bucket(ctx: Context, bucket_name: str) -> dict
     """Get the names of all scopes and collections for a specified bucket.
     Returns a dictionary with scope names as keys and lists of collection names as values.
     """
-    #bucket = ctx.request_context.lifespan_context.bucket
     cluster = ctx.request_context.lifespan_context.cluster
 
     try:
@@ -212,7 +198,6 @@ def get_document_by_id(
     ctx: Context, bucket_name: str, scope_name: str, collection_name: str, document_id: str
 ) -> dict[str, Any]:
     """Get a document by its ID from the specified bucket, scope and collection."""
-    #bucket = ctx.request_context.lifespan_context.bucket
     cluster = ctx.request_context.lifespan_context.cluster
     try:
         bucket = cluster.bucket(bucket_name)
@@ -239,7 +224,6 @@ def upsert_document_by_id(
 ) -> bool:
     """Insert or update a document in a bucket, scope and collection by its ID.
     Returns True on success, False on failure."""
-    #bucket = ctx.request_context.lifespan_context.bucket
     cluster = ctx.request_context.lifespan_context.cluster
     try:
         bucket = cluster.bucket(bucket_name)
@@ -262,7 +246,6 @@ def delete_document_by_id(
 ) -> bool:
     """Delete a document in a bucket, scope and collection by its ID.
     Returns True on success, False on failure."""
-    #bucket = ctx.request_context.lifespan_context.bucket
     cluster = ctx.request_context.lifespan_context.cluster
     try:
         bucket = cluster.bucket(bucket_name)
@@ -309,7 +292,6 @@ def run_sql_plus_plus_query(
     ctx: Context, bucket_name: str, scope_name: str, query: str
 ) -> list[dict[str, Any]]:
     """Run a SQL++ query on a scope in a specified bucket and return the results as a list of JSON objects."""
-    #bucket = ctx.request_context.lifespan_context.bucket
     cluster = ctx.request_context.lifespan_context.cluster
     try:
         bucket = cluster.bucket(bucket_name)


### PR DESCRIPTION
Adding mTLS support by accepting path to CA.crt file and path to client key and certificate. Client key and certificate must exist in the given path and be named client.key and client.pem respectively. If no CA.crt file is given, locally trusted CA is used.
mTLS and Basic Auth with username/password are mutually exclusive and handled as such (error is thrown if both are attempted - there is no dominant config).

mTLS config:

```json
{
  "mcpServers": {
    "couchbase": {
      "command": "uv",
      "args": [
        "--directory",
        "path/to/cloned/repo/mcp-server-couchbase/",
        "run",
        "src/mcp_server.py"
      ],
      "env": {
        "CB_CONNECTION_STRING": "couchbases://connection-string",
        "CLIENT_CERT_PATH": "path/to/client/cert_and_key/",
        "CA_CERT_PATH" : "path/to/ca.crt"
      }
    }
  }
}
```
