### PR TITLE
Enhance README.md with MCP Client Configuration examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,9 @@ An [MCP](https://modelcontextprotocol.io/) server implementation of Couchbase th
 
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/) [![PyPI version](https://badge.fury.io/py/couchbase-mcp-server.svg)](https://pypi.org/project/couchbase-mcp-server/) [![Verified on MseeP](https://mseep.ai/badge.svg)](https://mseep.ai/app/13fce476-0e74-4b1e-ab82-1df2a3204809)[![smithery badge](https://smithery.ai/badge/@Couchbase-Ecosystem/mcp-server-couchbase)](https://smithery.ai/server/@Couchbase-Ecosystem/mcp-server-couchbase)
 
-<p align="center">
 <a href="https://glama.ai/mcp/servers/@Couchbase-Ecosystem/mcp-server-couchbase">
-  <img width="250" height="130" src="https://glama.ai/mcp/servers/@Couchbase-Ecosystem/mcp-server-couchbase/badge" alt="Couchbase Server MCP server" />
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@Couchbase-Ecosystem/mcp-server-couchbase/badge" alt="Couchbase Server MCP server" />
 </a>
-</p>
 
 ## Features
 
@@ -261,7 +259,7 @@ docker build -t mcp/couchbase .
 
 The MCP server can be run with the environment variables being used to configure the Couchbase settings. The environment variables are the same as described in the [Configuration section](#server-configuration-for-mcp-clients).
 
-#### Indepdendent Docker Container
+#### Independent Docker Container
 
 ```bash
 docker run --rm -i \

--- a/README.md
+++ b/README.md
@@ -198,6 +198,18 @@ uvx couchbase-mcp-server --connection-string='<couchbase_connection_string>' --u
 
 The server will be available on http://localhost:8000/mcp. This can be used in MCP clients supporting streamable http transport mode such as Cursor.
 
+#### MCP Client Configuration
+
+```json
+{
+  "mcpServers": {
+    "couchbase-streamable-http-mode": {
+      "url": "http://localhost:8000/mcp"
+    }
+  }
+}
+```
+
 ### SSE Transport Mode
 
 There is an option to run the MCP server in [Server-Sent Events (SSE)](https://modelcontextprotocol.io/specification/2024-11-05/basic/transports#http-with-sse) transport mode.
@@ -214,9 +226,23 @@ By default, the MCP server will run on port 8000 but this can be configured usin
 
 The server will be available on http://localhost:8000/sse. This can be used in MCP clients supporting SSE transport mode such as Cursor.
 
+#### MCP Client Configuration
+
+```json
+{
+  "mcpServers": {
+    "couchbase-sse-mode": {
+      "url": "http://localhost:8000/sse"
+    }
+  }
+}
+```
+
 ## Docker Image
 
 The MCP server can also be built and run as a Docker container. Prebuilt images can be found on [DockerHub](https://hub.docker.com/r/couchbaseecosystem/mcp-server-couchbase).
+
+Alternatively, we are part of the [Docker MCP Catalog](https://hub.docker.com/mcp/server/couchbase/overview).
 
 ```bash
 docker build -t mcp/couchbase .
@@ -235,6 +261,32 @@ docker run -i \
   -e MCP_TRANSPORT='stdio/streamable-http/sse' \
   -e READ_ONLY_QUERY_MODE="true/false" \
   mcp/couchbase
+```
+
+#### MCP Client Configuration
+
+```json
+{
+  "mcpServers": {
+    "docker-cb": {
+      "command": "docker",
+      "args": [
+        "run",
+        "--rm",
+        "-i",
+        "-e",
+        "CB_CONNECTION_STRING=<couchbase_connection_string>",
+        "-e",
+        "CB_USERNAME=<database_user>",
+        "-e",
+        "CB_PASSWORD=<database_password>",
+        "-e",
+        "CB_BUCKET_NAME=<bucket_name>",
+        "mcp/couchbase"
+      ]
+    }
+  }
+}
 ```
 
 ### Risks Associated with LLMs

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ The server will be available on http://localhost:8000/mcp. This can be used in M
 ```json
 {
   "mcpServers": {
-    "couchbase-streamable-http-mode": {
+    "couchbase-streamable-http": {
       "url": "http://localhost:8000/mcp"
     }
   }
@@ -234,7 +234,7 @@ The server will be available on http://localhost:8000/sse. This can be used in M
 ```json
 {
   "mcpServers": {
-    "couchbase-sse-mode": {
+    "couchbase-sse": {
       "url": "http://localhost:8000/sse"
     }
   }
@@ -279,7 +279,7 @@ The `FASTMCP_PORT` environment variable is only applicable in the case of HTTP t
 ```json
 {
   "mcpServers": {
-    "docker-cb": {
+    "couchbase-mcp-docker": {
       "command": "docker",
       "args": [
         "run",

--- a/README.md
+++ b/README.md
@@ -257,9 +257,26 @@ docker build -t mcp/couchbase .
 
 The MCP server can be run with the environment variables being used to configure the Couchbase settings. The environment variables are the same as described in the [Configuration section](#server-configuration-for-mcp-clients).
 
+#### Indepdendent Docker Container
+
+```bash
+docker run --rm -i \
+  -e CB_CONNECTION_STRING='<couchbase_connection_string>' \
+  -e CB_USERNAME='<database_user>' \
+  -e CB_PASSWORD='<database_password>' \
+  -e CB_BUCKET_NAME='<bucket_name>' \
+  -e MCP_TRANSPORT='<stdio|streamable-http|sse>' \
+  -e READ_ONLY_QUERY_MODE=<true|false> \
+  -e FASTMCP_PORT=9001 \
+  -p 9001:9001 \
+  mcp/couchbase
+```
+
+The `FASTMCP_PORT` environment variable is only applicable in the case of HTTP transport modes like streamable-http and sse.
+
 #### MCP Client Configuration
 
-````json
+```json
 {
   "mcpServers": {
     "docker-cb": {
@@ -281,6 +298,7 @@ The MCP server can be run with the environment variables being used to configure
     }
   }
 }
+```
 
 Notes
 
@@ -342,7 +360,7 @@ uv run pre-commit install
 
 # Run linting
 ./scripts/lint.sh
-````
+```
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 An [MCP](https://modelcontextprotocol.io/) server implementation of Couchbase that allows LLMs to directly interact with Couchbase clusters.
 
-[![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/) [![PyPI version](https://badge.fury.io/py/couchbase-mcp-server.svg)](https://pypi.org/project/couchbase-mcp-server/) [![Verified on MseeP](https://mseep.ai/badge.svg)](https://mseep.ai/app/13fce476-0e74-4b1e-ab82-1df2a3204809)[![smithery badge](https://smithery.ai/badge/@Couchbase-Ecosystem/mcp-server-couchbase)](https://smithery.ai/server/@Couchbase-Ecosystem/mcp-server-couchbase)
+[![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/) [![PyPI version](https://badge.fury.io/py/couchbase-mcp-server.svg)](https://pypi.org/project/couchbase-mcp-server/) [![Verified on MseeP](https://mseep.ai/badge.svg)](https://mseep.ai/app/13fce476-0e74-4b1e-ab82-1df2a3204809) [![smithery badge](https://smithery.ai/badge/@Couchbase-Ecosystem/mcp-server-couchbase)](https://smithery.ai/server/@Couchbase-Ecosystem/mcp-server-couchbase)
 
 <a href="https://glama.ai/mcp/servers/@Couchbase-Ecosystem/mcp-server-couchbase">
   <img width="380" height="200" src="https://glama.ai/mcp/servers/@Couchbase-Ecosystem/mcp-server-couchbase/badge" alt="Couchbase Server MCP server" />
@@ -267,8 +267,8 @@ docker run --rm -i \
   -e CB_USERNAME='<database_user>' \
   -e CB_PASSWORD='<database_password>' \
   -e CB_BUCKET_NAME='<bucket_name>' \
-  -e MCP_TRANSPORT='<stdio|streamable-http|sse>' \
-  -e READ_ONLY_QUERY_MODE=<true|false> \
+  -e MCP_TRANSPORT='streamable-http|sse|stdio' \
+  -e READ_ONLY_QUERY_MODE='true|false' \
   -e FASTMCP_PORT=9001 \
   -p 9001:9001 \
   mcp/couchbase
@@ -277,6 +277,8 @@ docker run --rm -i \
 The `FASTMCP_PORT` environment variable is only applicable in the case of HTTP transport modes like streamable-http and sse.
 
 #### MCP Client Configuration
+
+The Docker image can be used in `stdio` transport mode wiht the following configuration.
 
 ```json
 {
@@ -288,13 +290,13 @@ The `FASTMCP_PORT` environment variable is only applicable in the case of HTTP t
         "--rm",
         "-i",
         "-e",
-        "CB_CONNECTION_STRING='<couchbase_connection_string>'",
+        "CB_CONNECTION_STRING=<couchbase_connection_string>",
         "-e",
-        "CB_USERNAME='<database_user>'",
+        "CB_USERNAME=<database_user>",
         "-e",
-        "CB_PASSWORD='<database_password>'",
+        "CB_PASSWORD=<database_password>",
         "-e",
-        "CB_BUCKET_NAME='<bucket_name>'",
+        "CB_BUCKET_NAME=<bucket_name>",
         "mcp/couchbase"
       ]
     }

--- a/README.md
+++ b/README.md
@@ -267,8 +267,8 @@ docker run --rm -i \
   -e CB_USERNAME='<database_user>' \
   -e CB_PASSWORD='<database_password>' \
   -e CB_BUCKET_NAME='<bucket_name>' \
-  -e MCP_TRANSPORT='streamable-http|sse|stdio' \
-  -e READ_ONLY_QUERY_MODE='true|false' \
+  -e MCP_TRANSPORT='<streamable-http|sse|stdio>' \
+  -e READ_ONLY_QUERY_MODE='<true|false>' \
   -e FASTMCP_PORT=9001 \
   -p 9001:9001 \
   mcp/couchbase
@@ -278,7 +278,7 @@ The `FASTMCP_PORT` environment variable is only applicable in the case of HTTP t
 
 #### MCP Client Configuration
 
-The Docker image can be used in `stdio` transport mode wiht the following configuration.
+The Docker image can be used in `stdio` transport mode with the following configuration.
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -2,9 +2,13 @@
 
 An [MCP](https://modelcontextprotocol.io/) server implementation of Couchbase that allows LLMs to directly interact with Couchbase clusters.
 
+[![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/) [![PyPI version](https://badge.fury.io/py/couchbase-mcp-server.svg)](https://pypi.org/project/couchbase-mcp-server/) [![Verified on MseeP](https://mseep.ai/badge.svg)](https://mseep.ai/app/13fce476-0e74-4b1e-ab82-1df2a3204809)[![smithery badge](https://smithery.ai/badge/@Couchbase-Ecosystem/mcp-server-couchbase)](https://smithery.ai/server/@Couchbase-Ecosystem/mcp-server-couchbase)
+
+<p align="center">
 <a href="https://glama.ai/mcp/servers/@Couchbase-Ecosystem/mcp-server-couchbase">
-  <img width="380" height="200" src="https://glama.ai/mcp/servers/@Couchbase-Ecosystem/mcp-server-couchbase/badge" alt="Couchbase Server MCP server" />
+  <img width="250" height="130" src="https://glama.ai/mcp/servers/@Couchbase-Ecosystem/mcp-server-couchbase/badge" alt="Couchbase Server MCP server" />
 </a>
+</p>
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -184,11 +184,11 @@ For more details about MCP integration with Windsurf Editor, refer to the offici
 
 </details>
 
-### Streamable HTTP Transport Mode
+## Streamable HTTP Transport Mode
 
-The MCP Server can be run in [Streamable HTTP](https://modelcontextprotocol.io/specification/2025-06-18/basic/transports#streamable-http) transport mode.
+The MCP Server can be run in [Streamable HTTP](https://modelcontextprotocol.io/specification/2025-06-18/basic/transports#streamable-http) transport mode which allows multiple clients to connect to the same server instance via HTTP.
 
-#### Usage
+### Usage
 
 By default, the MCP server will run on port 8000 but this can be configured using the `--port` or `FASTMCP_PORT` environment variable.
 
@@ -198,7 +198,7 @@ uvx couchbase-mcp-server --connection-string='<couchbase_connection_string>' --u
 
 The server will be available on http://localhost:8000/mcp. This can be used in MCP clients supporting streamable http transport mode such as Cursor.
 
-#### MCP Client Configuration
+### MCP Client Configuration
 
 ```json
 {
@@ -210,13 +210,13 @@ The server will be available on http://localhost:8000/mcp. This can be used in M
 }
 ```
 
-### SSE Transport Mode
+## SSE Transport Mode (Deprecated)
 
 There is an option to run the MCP server in [Server-Sent Events (SSE)](https://modelcontextprotocol.io/specification/2024-11-05/basic/transports#http-with-sse) transport mode.
 
-> Note: SSE mode has been [deprecated](https://modelcontextprotocol.io/docs/concepts/transports#server-sent-events-sse-deprecated) by MCP. We have support for Streamable HTTP.
+> Note: SSE mode has been [deprecated](https://modelcontextprotocol.io/docs/concepts/transports#server-sent-events-sse-deprecated) by MCP. We have support for [Streamable HTTP](#streamable-http-transport-mode).
 
-#### Usage
+### Usage
 
 By default, the MCP server will run on port 8000 but this can be configured using the `--port` or `FASTMCP_PORT` environment variable.
 
@@ -226,7 +226,7 @@ By default, the MCP server will run on port 8000 but this can be configured usin
 
 The server will be available on http://localhost:8000/sse. This can be used in MCP clients supporting SSE transport mode such as Cursor.
 
-#### MCP Client Configuration
+### MCP Client Configuration
 
 ```json
 {
@@ -243,6 +243,8 @@ The server will be available on http://localhost:8000/sse. This can be used in M
 The MCP server can also be built and run as a Docker container. Prebuilt images can be found on [DockerHub](https://hub.docker.com/r/couchbaseecosystem/mcp-server-couchbase).
 
 Alternatively, we are part of the [Docker MCP Catalog](https://hub.docker.com/mcp/server/couchbase/overview).
+
+### Building Image
 
 ```bash
 docker build -t mcp/couchbase .
@@ -275,13 +277,13 @@ docker run -i \
         "--rm",
         "-i",
         "-e",
-        "CB_CONNECTION_STRING=<couchbase_connection_string>",
+        "CB_CONNECTION_STRING='<couchbase_connection_string>'",
         "-e",
-        "CB_USERNAME=<database_user>",
+        "CB_USERNAME='<database_user>'",
         "-e",
-        "CB_PASSWORD=<database_password>",
+        "CB_PASSWORD='<database_password>'",
         "-e",
-        "CB_BUCKET_NAME=<bucket_name>",
+        "CB_BUCKET_NAME='<bucket_name>'",
         "mcp/couchbase"
       ]
     }


### PR DESCRIPTION
- Added configuration examples for MCP clients in both streamable HTTP and SSE transport modes.
- Included Docker run command configuration for MCP server in a Docker container.