### PR TITLE
Add build script and enhance Dockerfile with metadata labels for comm…

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -43,6 +43,10 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=raw,value=latest
 
+      - name: Set build timestamp
+        id: timestamp
+        run: echo "BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_OUTPUT
+
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
         with:
@@ -51,6 +55,9 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            GIT_COMMIT_HASH=${{ github.sha }}
+            BUILD_DATE=${{ steps.timestamp.outputs.BUILD_DATE }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,17 @@ RUN uv venv /opt/venv && \
 # Runtime stage - use Python image with same version as builder
 FROM python:3.10-slim-bookworm AS runtime
 
+# Accept build arguments for labels
+ARG GIT_COMMIT_HASH="unknown"
+ARG BUILD_DATE="unknown"
+
+# Add metadata labels
+LABEL org.opencontainers.image.revision="${GIT_COMMIT_HASH}" \
+    org.opencontainers.image.created="${BUILD_DATE}" \
+    org.opencontainers.image.title="MCP Server Couchbase" \
+    org.opencontainers.image.description="Model Context Protocol server for Couchbase" \
+    org.opencontainers.image.source="https://github.com/couchbaselabs/mcp-server-couchbase"
+
 # Create non-root user
 RUN useradd --system --uid 1001 mcpuser
 

--- a/README.md
+++ b/README.md
@@ -261,6 +261,41 @@ Alternatively, we are part of the [Docker MCP Catalog](https://hub.docker.com/mc
 docker build -t mcp/couchbase .
 ```
 
+<details>
+<summary>Building with Arguments</summary>
+If you want to build with the build arguments for commit hash and the build time, you can build using:
+
+```bash
+docker build --build-arg GIT_COMMIT_HASH=$(git rev-parse HEAD) \
+  --build-arg BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ') \
+  -t mcp/couchbase .
+```
+
+**Alternatively, use the provided build script:**
+
+```bash
+./build.sh
+```
+
+This script automatically:
+
+- Generates git commit hash and build timestamp
+- Creates multiple useful tags (`latest`, `<short-commit>`)
+- Shows build information and results
+- Uses the same arguments as CI/CD builds
+
+**Verify image labels:**
+
+```bash
+# View git commit hash in image
+docker inspect mcp/couchbase:latest | jq -r '.[0].Config.Labels["org.opencontainers.image.revision"]'
+
+# View all metadata labels
+docker inspect mcp/couchbase:latest | jq '.[0].Config.Labels'
+```
+
+</details>
+
 ### Running
 
 The MCP server can be run with the environment variables being used to configure the Couchbase settings. The environment variables are the same as described in the [Configuration section](#server-configuration-for-mcp-clients).

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Get git information
+GIT_COMMIT=$(git rev-parse HEAD)
+GIT_SHORT_COMMIT=$(git rev-parse --short HEAD)
+BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+
+echo "Building Docker image with:"
+echo "  Git Commit: $GIT_COMMIT"
+echo "  Build Date: $BUILD_DATE"
+
+# Build the Docker image
+docker build \
+  --build-arg GIT_COMMIT_HASH="$GIT_COMMIT" \
+  --build-arg BUILD_DATE="$BUILD_DATE" \
+  -t "mcp/couchbase:$GIT_SHORT_COMMIT" \
+  -t "mcp/couchbase:latest" \
+  .
+
+echo "Build complete!"
+echo "Tagged as:"
+echo "  - mcp/couchbase:$GIT_SHORT_COMMIT"
+echo "  - mcp/couchbase:latest"


### PR DESCRIPTION
…it hash and build date

- Introduced a new `build.sh` script to automate Docker image builds, including git commit hash and build date as arguments.
- Updated `Dockerfile` to accept build arguments for git commit hash and build date, adding corresponding metadata labels.
- Enhanced `README.md` with instructions for using the new build script and building with arguments.
- Modified GitHub Actions workflow to set the build date and pass it along with the commit hash during Docker image builds.