### PR TITLE
Potential fix for code scanning alert no. 6: Code injection

### DIFF
--- a/.github/workflows/update-mcp-registry.yml
+++ b/.github/workflows/update-mcp-registry.yml
@@ -141,7 +141,9 @@ jobs:
 
       - name: Notify completion
         if: success()
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
-          echo "MCP Registry updated successfully for version ${{ steps.version.outputs.version }}"
-          echo "Docker image: docker.io/couchbaseecosystem/mcp-server-couchbase:${{ steps.version.outputs.version }}"
-          echo "PyPI package: couchbase-mcp-server==${{ steps.version.outputs.version }}"
+          echo "MCP Registry updated successfully for version $VERSION"
+          echo "Docker image: docker.io/couchbaseecosystem/mcp-server-couchbase:$VERSION"
+          echo "PyPI package: couchbase-mcp-server==$VERSION"


### PR DESCRIPTION
Potential fix for [https://github.com/Couchbase-Ecosystem/mcp-server-couchbase/security/code-scanning/6](https://github.com/Couchbase-Ecosystem/mcp-server-couchbase/security/code-scanning/6)

To fix the code injection risk, values that may be influenced by untrusted input (such as version strings from files committed to the repo) must not be interpolated into `run:` blocks using `${{ ... }}` syntax. Instead, these should be set as environment variables at the step level and referenced using native shell variable syntax (`$VAR`). Specifically: in the "Notify completion" step (lines 142-148), move the assignment of `steps.version.outputs.version` to an environment variable, then reference it within the `run` block using `$VERSION`. The rest of the use of `$VERSION` remains unchanged. This avoids shell injection, as the shell variable is properly quoted and parsed.

Changes involved:
- In step 142 ("Notify completion"), add an `env:` section to assign `VERSION: ${{ steps.version.outputs.version }}`.
- In the associated shell script (lines 145-147), replace references to `${{ steps.version.outputs.version }}` with `$VERSION`.

No changes are needed elsewhere in the file to accomplish this error fix.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
