### PR TITLE
Update schema in server.json 

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -115,13 +115,11 @@ git push origin v0.5.2
 Once the tag is pushed, three GitHub Actions workflows run **in parallel/sequence**:
 
 1. **PyPI Release**
-
    - Builds Python package
    - Publishes to PyPI as `couchbase-mcp-server`
    - Creates GitHub Release with changelog
 
 2. **Docker Build**
-
    - Builds multi-architecture images (amd64, arm64)
    - Pushes to Docker Hub as `couchbaseecosystem/mcp-server-couchbase`
    - Updates Docker Hub description
@@ -132,6 +130,8 @@ Once the tag is pushed, three GitHub Actions workflows run **in parallel/sequenc
    - Publishes to MCP Registry
 
 > **Note:** Version validation happens in the MCP Registry workflow, which runs **after** PyPI and Docker have already published. This is why local validation (step 2) is critical!
+
+> **Note:** The MCP regsitry entry can be validated using this [third party option](https://registry.teamspark.ai/tester) before releasing or for debugging.
 
 ### 5. Verify Release
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -131,7 +131,7 @@ Once the tag is pushed, three GitHub Actions workflows run **in parallel/sequenc
 
 > **Note:** Version validation happens in the MCP Registry workflow, which runs **after** PyPI and Docker have already published. This is why local validation (step 2) is critical!
 
-> **Note:** The MCP regsitry entry can be validated using this [third party option](https://registry.teamspark.ai/tester) before releasing or for debugging.
+> **Note:** The MCP registry entry can be validated using this [third party option](https://registry.teamspark.ai/tester) before releasing or for debugging.
 
 ### 5. Verify Release
 

--- a/server.json
+++ b/server.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.Couchbase-Ecosystem/mcp-server-couchbase",
   "description": "Couchbase Model Context Protocol Server to interact with Couchbase clusters",
   "repository": {

--- a/server.json
+++ b/server.json
@@ -59,8 +59,15 @@
           "isSecret": false
         },
         {
+          "name": "CB_MCP_READ_ONLY_MODE",
+          "description": "Couchbase read only query mode. Set to true to allow disable write operations across both KV and query. KV write tools are not loaded and SQL++ queries that modify data are blocked. Set to false to allow data modification queries and tools.",
+          "isRequired": false,
+          "format": "boolean",
+          "isSecret": false
+        },
+        {
           "name": "CB_MCP_READ_ONLY_QUERY_MODE",
-          "description": "Couchbase read only query mode. Set to true to allow only read-only queries. Set to false to allow data modification queries.",
+          "description": "[Deprecated] Couchbase read only query mode. Set to true to allow only read-only queries. Set to false to allow data modification queries. Use CB_MCP_READ_ONLY_MODE instead.",
           "isRequired": false,
           "format": "boolean",
           "isSecret": false
@@ -84,6 +91,13 @@
           "description": "Port to run the MCP server on (default: 8000). Used only for HTTP and SSE transport modes.",
           "isRequired": false,
           "format": "number",
+          "isSecret": false
+        },
+        {
+          "name": "CB_MCP_DISABLED_TOOLS",
+          "description": "Tools to disable. Accepts comma-separated tool names (e.g., 'tool_1,tool_2') or a file path containing one tool name per line.",
+          "isRequired": false,
+          "format": "string",
           "isSecret": false
         }
       ],
@@ -138,8 +152,16 @@
         },
         {
           "type": "named",
+          "name": "--read-only-mode",
+          "description": "Couchbase read only mode. Set to true to disable write operations across both KV and query. KV write tools are not loaded and SQL++ queries that modify data are blocked. Set to false to allow data modification queries and tools.",
+          "isRequired": false,
+          "format": "boolean",
+          "isSecret": false
+        },
+        {
+          "type": "named",
           "name": "--read-only-query-mode",
-          "description": "Couchbase read only query mode. Set to true to allow only read-only queries. Set to false to allow data modification queries.",
+          "description": "[Deprecated] Couchbase read only query mode. Set to true to allow only read-only queries. Set to false to allow data modification queries. Use --read-only-mode instead.",
           "isRequired": false,
           "format": "boolean",
           "isSecret": false
@@ -166,6 +188,14 @@
           "description": "Port to run the MCP server on (default: 8000). Used only for HTTP and SSE transport modes.",
           "isRequired": false,
           "format": "number",
+          "isSecret": false
+        },
+        {
+          "type": "named",
+          "name": "--disabled-tools",
+          "description": "Tools to disable. Accepts comma-separated tool names (e.g., 'tool_1,tool_2') or a file path containing one tool name per line.",
+          "isRequired": false,
+          "format": "string",
           "isSecret": false
         }
       ]
@@ -220,8 +250,15 @@
           "isSecret": false
         },
         {
+          "name": "CB_MCP_READ_ONLY_MODE",
+          "description": "Couchbase read only mode. Set to true to disable write operations across both KV and query. KV write tools are not loaded and SQL++ queries that modify data are blocked. Set to false to allow data modification queries and tools.",
+          "isRequired": false,
+          "format": "boolean",
+          "isSecret": false
+        },
+        {
           "name": "CB_MCP_READ_ONLY_QUERY_MODE",
-          "description": "Couchbase read only query mode. Set to true to allow only read-only queries. Set to false to allow data modification queries.",
+          "description": "[Deprecated] Couchbase read only query mode. Set to true to allow only read-only queries. Set to false to allow data modification queries. Use CB_MCP_READ_ONLY_MODE instead.",
           "isRequired": false,
           "format": "boolean",
           "isSecret": false
@@ -245,6 +282,13 @@
           "description": "Port to run the MCP server on (default: 8000). Used only for HTTP and SSE transport modes.",
           "isRequired": false,
           "format": "number",
+          "isSecret": false
+        },
+        {
+          "name": "CB_MCP_DISABLED_TOOLS",
+          "description": "Tools to disable. Accepts comma-separated tool names (e.g., 'tool_1,tool_2') or a file path containing one tool name per line.",
+          "isRequired": false,
+          "format": "string",
           "isSecret": false
         }
       ]

--- a/server.json
+++ b/server.json
@@ -60,7 +60,7 @@
         },
         {
           "name": "CB_MCP_READ_ONLY_MODE",
-          "description": "Couchbase read only query mode. Set to true to allow disable write operations across both KV and query. KV write tools are not loaded and SQL++ queries that modify data are blocked. Set to false to allow data modification queries and tools.",
+          "description": "Couchbase read only mode. Set to true to allow disable write operations across both KV and query. KV write tools are not loaded and SQL++ queries that modify data are blocked. Set to false to allow data modification queries and tools.",
           "isRequired": false,
           "format": "boolean",
           "isSecret": false


### PR DESCRIPTION
* Schema Version Update: The $schema field in server.json has been updated to reference the 2025-12-11 version of the schema, moving from the previous 2025-10-17 version.
* New Configuration Options: Introduced CB_MCP_READ_ONLY_MODE and --read-only-mode to control read-only mode, deprecating CB_MCP_READ_ONLY_QUERY_MODE and --read-only-query-mode. Also added CB_MCP_DISABLED_TOOLS and --disabled-tools to disable specific tools.
* Release Documentation Update: Added a note to RELEASE.md about validating the MCP registry entry using a third-party option before releasing or for debugging.