### PR TITLE
Add Scarf gateway as Docker pull option 

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -79,7 +79,7 @@ Add the configuration specified below to the MCP configuration in your MCP clien
         "CB_USERNAME=<database_username>",
         "-e",
         "CB_PASSWORD=<database_password>",
-        "couchbaseecosystem/mcp-server-couchbase:latest"
+        "couchbase.docker.scarf.sh/couchbaseecosystem/mcp-server-couchbase:latest"
       ]
     }
   }

--- a/README.md
+++ b/README.md
@@ -487,7 +487,7 @@ The server will be available on http://localhost:8000/sse. This can be used in M
 
 ## Docker Image
 
-The MCP server can also be built and run as a Docker container. Prebuilt images can be found on [DockerHub](https://hub.docker.com/r/couchbaseecosystem/mcp-server-couchbase).
+The MCP server can also be built and run as a Docker container. Prebuilt images can be found on [DockerHub](https://hub.docker.com/r/couchbaseecosystem/mcp-server-couchbase) or pulled via `docker pull couchbase.docker.scarf.sh/couchbaseecosystem/mcp-server-couchbase`.
 
 Alternatively, we are part of the [Docker MCP Catalog](https://hub.docker.com/mcp/server/couchbase/overview).
 


### PR DESCRIPTION
Add[ Scarf analytics gateway URL](https://docs.scarf.sh/packages/) as an alternative Docker pull source in documentation (README.md, DOCKER.md) to enable download tracking via Scarf.