### PR TITLE
DA-1616 Remove delete as default in Elicitation

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -111,8 +111,8 @@ The detailed explanation for the environment variables can be found on the [GitH
 | `CB_MCP_TRANSPORT`            | Transport mode (stdio/http/sse)                                                                           | `stdio`                                                        |
 | `CB_MCP_HOST`                 | Server host (HTTP/SSE modes)                                                                              | `127.0.0.1`                                                    |
 | `CB_MCP_PORT`                 | Server port (HTTP/SSE modes)                                                                              | `8000`                                                         |
-| `CB_MCP_DISABLED_TOOLS`       | Tools to disable                                                                                          | None |
-| `CB_MCP_CONFIRMATION_REQUIRED_TOOLS` | Tools that require explicit user confirmation before execution (via MCP elicitation)                 | None |
+| `CB_MCP_DISABLED_TOOLS`              | Tools to disable (see [Disabling Tools](#disabling-tools))                                                | None                                                           |
+| `CB_MCP_CONFIRMATION_REQUIRED_TOOLS` | Tools that require explicit user confirmation before execution (see [Confirmation Required Tools](#confirmation-required-tools)) | None                                                           |
 
 ### Disabling Tools
 
@@ -219,3 +219,64 @@ Lines starting with `#` are treated as comments and ignored.
 > - The database user lacks the necessary RBAC permissions for data modification
 >
 > **Best Practice:** Always configure appropriate RBAC permissions on your Couchbase user credentials as the primary security measure. Use `CB_MCP_READ_ONLY_MODE=true` (the default) for comprehensive write protection, and tool disabling as an additional layer to guide LLM behavior.
+
+### Confirmation Required Tools
+
+You can require explicit user confirmation for specific tools before execution (when the MCP client supports [elicitation](https://modelcontextprotocol.io/specification/2025-06-18/server/elicitation)).
+
+#### Configuration Formats
+
+**Comma-separated list:**
+
+```bash
+CB_MCP_CONFIRMATION_REQUIRED_TOOLS="delete_document_by_id,replace_document_by_id"
+```
+
+**File path (one tool name per line):**
+
+```bash
+CB_MCP_CONFIRMATION_REQUIRED_TOOLS=confirmation_tools.txt
+```
+
+**File format (e.g., `confirmation_tools.txt`):**
+
+```text
+# Destructive operations
+delete_document_by_id
+replace_document_by_id
+```
+
+Lines starting with `#` are treated as comments and ignored.
+
+#### Behavior
+
+When a listed tool is invoked:
+
+- If the client supports elicitation, the user is prompted to confirm before execution.
+- If the client does not support elicitation, the tool executes without confirmation for backward compatibility.
+
+#### MCP Client Configuration Example
+
+```json
+{
+  "mcpServers": {
+    "couchbase": {
+      "command": "docker",
+      "args": [
+        "run",
+        "--rm",
+        "-i",
+        "-e",
+        "CB_CONNECTION_STRING=couchbases://connection-string",
+        "-e",
+        "CB_USERNAME=username",
+        "-e",
+        "CB_PASSWORD=password",
+        "-e",
+        "CB_MCP_CONFIRMATION_REQUIRED_TOOLS=delete_document_by_id,replace_document_by_id",
+        "couchbase.docker.scarf.sh/couchbaseecosystem/mcp-server-couchbase:latest"
+      ]
+    }
+  }
+}
+```

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -111,8 +111,8 @@ The detailed explanation for the environment variables can be found on the [GitH
 | `CB_MCP_TRANSPORT`            | Transport mode (stdio/http/sse)                                                                           | `stdio`                                                        |
 | `CB_MCP_HOST`                 | Server host (HTTP/SSE modes)                                                                              | `127.0.0.1`                                                    |
 | `CB_MCP_PORT`                 | Server port (HTTP/SSE modes)                                                                              | `8000`                                                         |
-| `CB_MCP_DISABLED_TOOLS`       | Tools to disable                                                                                          |                                                                |
-| `CB_MCP_CONFIRMATION_REQUIRED_TOOLS` | Tools that require explicit user confirmation before execution (via MCP elicitation)                 |                                       |
+| `CB_MCP_DISABLED_TOOLS`       | Tools to disable                                                                                          | None |
+| `CB_MCP_CONFIRMATION_REQUIRED_TOOLS` | Tools that require explicit user confirmation before execution (via MCP elicitation)                 | None |
 
 ### Disabling Tools
 

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -112,7 +112,7 @@ The detailed explanation for the environment variables can be found on the [GitH
 | `CB_MCP_HOST`                 | Server host (HTTP/SSE modes)                                                                              | `127.0.0.1`                                                    |
 | `CB_MCP_PORT`                 | Server port (HTTP/SSE modes)                                                                              | `8000`                                                         |
 | `CB_MCP_DISABLED_TOOLS`       | Tools to disable                                                                                          |                                                                |
-| `CB_MCP_CONFIRMATION_REQUIRED_TOOLS` | Tools that require explicit user confirmation before execution (via MCP elicitation)                 | `delete_document_by_id`                                        |
+| `CB_MCP_CONFIRMATION_REQUIRED_TOOLS` | Tools that require explicit user confirmation before execution (via MCP elicitation)                 |                                       |
 
 ### Disabling Tools
 

--- a/README.md
+++ b/README.md
@@ -317,7 +317,6 @@ When a listed tool is invoked:
 - If the client supports elicitation, the user is prompted to confirm.
 - If the client does not support elicitation, the tool executes without confirmation for backward compatibility.
 
-By default, `delete_document_by_id` requires confirmation.
 
 You can also check the version of the server using:
 

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ The server can be configured using environment variables or command line argumen
 | `CB_MCP_HOST` | `--host` | Host for HTTP/SSE transport modes | `127.0.0.1` |
 | `CB_MCP_PORT` | `--port` | Port for HTTP/SSE transport modes | `8000` |
 | `CB_MCP_DISABLED_TOOLS` | `--disabled-tools` | Tools to disable (see [Disabling Tools](#disabling-tools)) | None |
-| `CB_MCP_CONFIRMATION_REQUIRED_TOOLS` | `--confirmation-required-tools` | Tools that require explicit user confirmation before execution via MCP elicitation (see [Confirmation Required Tools](#confirmation-required-tools)) | `delete_document_by_id` |
+| `CB_MCP_CONFIRMATION_REQUIRED_TOOLS` | `--confirmation-required-tools` | Tools that require explicit user confirmation before execution via MCP elicitation (see [Confirmation Required Tools](#confirmation-required-tools)) | None |
 
 #### Read-Only Mode Configuration
 

--- a/scripts/setup_test_data.py
+++ b/scripts/setup_test_data.py
@@ -21,21 +21,22 @@ Environment variables required:
 This script should be run before pytest to ensure tests don't skip.
 """
 
+import base64
+import json
 import os
 import sys
 import time
-import urllib.request
 import urllib.error
-import base64
-import json
+import urllib.request
 
 # Add src to path for imports
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
+from datetime import timedelta
+
+from couchbase.auth import PasswordAuthenticator
 from couchbase.cluster import Cluster
 from couchbase.options import ClusterOptions
-from couchbase.auth import PasswordAuthenticator
-from datetime import timedelta
 
 
 def get_env_or_exit(var_name: str) -> str:
@@ -131,7 +132,10 @@ def create_indexes(cluster: Cluster, bucket_name: str) -> None:
             error_msg = str(e)
             if "already exists" in error_msg.lower():
                 print(f"  - {description} already exists")
-            elif "not found" in error_msg.lower() or "does not exist" in error_msg.lower():
+            elif (
+                "not found" in error_msg.lower()
+                or "does not exist" in error_msg.lower()
+            ):
                 print(f"  - Skipped {description} (scope/collection not found)")
             else:
                 print(f"  - Warning: Could not create {description}: {e}")
@@ -155,7 +159,9 @@ def wait_for_indexes(cluster: Cluster, timeout_seconds: int = 180) -> bool:
                 return True
 
             elapsed = int(time.time() - start_time)
-            print(f"  - Waiting for {building_count} indexes to be built... ({elapsed}s elapsed)")
+            print(
+                f"  - Waiting for {building_count} indexes to be built... ({elapsed}s elapsed)"
+            )
             time.sleep(3)
 
         except Exception as e:
@@ -194,14 +200,8 @@ def check_scope_exists(bucket, scope_name: str) -> bool:
         return False
 
 
-def run_test_queries_inventory(cluster: Cluster, bucket_name: str) -> None:
-    """Run queries against travel-sample inventory scope (full sample data)."""
-    bucket = cluster.bucket(bucket_name)
-    scope = bucket.scope("inventory")
-
-    print("  Using inventory scope (travel-sample with sample data)...")
-
-    # Regular SELECT queries (for longest running, most frequent, response sizes)
+def _run_inventory_select_queries(scope) -> None:
+    """Run regular SELECT and PRIMARY index queries."""
     print("  - Running regular SELECT queries...")
     for _ in range(3):
         result = scope.query("SELECT * FROM airline LIMIT 100")
@@ -210,7 +210,6 @@ def run_test_queries_inventory(cluster: Cluster, bucket_name: str) -> None:
     result = scope.query("SELECT * FROM route LIMIT 500")
     list(result)
 
-    # Queries using PRIMARY index
     print("  - Running queries using primary index...")
     try:
         result = scope.query(
@@ -220,7 +219,9 @@ def run_test_queries_inventory(cluster: Cluster, bucket_name: str) -> None:
     except Exception:
         pass  # May fail depending on data
 
-    # Queries that fetch after index scan (not using covering index)
+
+def _run_inventory_fetch_queries(scope) -> None:
+    """Run queries requiring fetch after index scan (not using covering index)."""
     print("  - Running queries requiring fetch after index scan...")
     result = scope.query(
         "SELECT * FROM airline WHERE country = 'United States' LIMIT 50"
@@ -233,75 +234,69 @@ def run_test_queries_inventory(cluster: Cluster, bucket_name: str) -> None:
         )
         list(result)
 
-    # Queries that are non-selective (indexScan > resultCount)
+
+def _run_inventory_non_selective_queries(scope) -> None:
+    """Run non-selective queries (indexScan > resultCount)."""
     print("  - Running non-selective queries (using secondary indexes)...")
 
-    # Use sourceairport index on route
-    try:
-        result = scope.query("""
-            SELECT * FROM route 
+    non_selective_queries = [
+        """
+            SELECT * FROM route
             WHERE sourceairport >= 'A' AND sourceairport < 'Z'
             AND destinationairport = 'XXXXX'
-        """)
-        list(result)
-    except Exception:
-        pass
-
-    # Use city index on airport
-    try:
-        result = scope.query("""
-            SELECT * FROM airport 
+        """,
+        """
+            SELECT * FROM airport
             WHERE city >= 'A' AND city < 'Z'
             AND faa = 'XXXX'
-        """)
-        list(result)
-    except Exception:
-        pass
-
-    # Use city index on hotel
-    try:
-        result = scope.query("""
-            SELECT * FROM hotel 
+        """,
+        """
+            SELECT * FROM hotel
             WHERE city >= 'A' AND city < 'Z'
             AND name LIKE 'ZZZZZZ%'
-        """)
-        list(result)
-    except Exception:
-        pass
-
-    # Use faa index on airport
-    try:
-        result = scope.query("""
-            SELECT * FROM airport 
+        """,
+        """
+            SELECT * FROM airport
             WHERE faa >= 'A' AND faa < 'Z'
             AND country = 'XXXXXX'
-        """)
-        list(result)
-    except Exception:
-        pass
+        """,
+    ]
+    for q in non_selective_queries:
+        try:
+            result = scope.query(q)
+            list(result)
+        except Exception:
+            pass
 
-    # Additional varied queries
+
+def _run_inventory_varied_queries(scope) -> None:
+    """Run additional varied queries."""
     print("  - Running additional varied queries...")
-    result = scope.query("SELECT COUNT(*) as cnt FROM airline")
-    list(result)
+    varied_queries = [
+        "SELECT COUNT(*) as cnt FROM airline",
+        "SELECT DISTINCT country FROM airline",
+        "SELECT name, country FROM airline ORDER BY name LIMIT 20",
+        "SELECT name, keyspace_id, index_key FROM system:indexes WHERE bucket_id = 'travel-sample' AND state = 'online'",
+        "SELECT * FROM airport WHERE faa >= 'A' AND faa < 'Z' AND country = 'XXXXXX'",
+        "SELECT * FROM airport WHERE faa >= 'A' AND faa < 'Z' AND country = 'XXXXXX'",
+        "SELECT * FROM hotel WHERE city >= 'A' AND city < 'Z' AND name LIKE 'ZZZZZZ%'",
+    ]
+    for q in varied_queries:
+        result = scope.query(q)
+        list(result)
 
-    result = scope.query("SELECT DISTINCT country FROM airline")
-    list(result)
 
-    result = scope.query("SELECT name, country FROM airline ORDER BY name LIMIT 20")
-    list(result)
+def run_test_queries_inventory(cluster: Cluster, bucket_name: str) -> None:
+    """Run queries against travel-sample inventory scope (full sample data)."""
+    bucket = cluster.bucket(bucket_name)
+    scope = bucket.scope("inventory")
 
-    result = scope.query("SELECT name, keyspace_id, index_key FROM system:indexes WHERE bucket_id = 'travel-sample' AND state = 'online'")
-    list(result)
+    print("  Using inventory scope (travel-sample with sample data)...")
 
-    result = scope.query("SELECT * FROM airport WHERE faa >= 'A' AND faa < 'Z' AND country = 'XXXXXX'")
-    list(result)
-
-    result = scope.query("SELECT * FROM airport WHERE faa >= 'A' AND faa < 'Z' AND country = 'XXXXXX'")
-    list(result)
-
-    result = scope.query("SELECT * FROM hotel WHERE city >= 'A' AND city < 'Z' AND name LIKE 'ZZZZZZ%'")
-    list(result)
+    _run_inventory_select_queries(scope)
+    _run_inventory_fetch_queries(scope)
+    _run_inventory_non_selective_queries(scope)
+    _run_inventory_varied_queries(scope)
 
 
 def run_test_queries_default(cluster: Cluster, bucket_name: str) -> None:
@@ -324,9 +319,7 @@ def run_test_queries_default(cluster: Cluster, bucket_name: str) -> None:
     # Queries using PRIMARY index
     print("  - Running queries using primary index...")
     try:
-        result = scope.query(
-            f"SELECT META().id, * FROM `{collection_name}` LIMIT 10"
-        )
+        result = scope.query(f"SELECT META().id, * FROM `{collection_name}` LIMIT 10")
         list(result)
     except Exception:
         pass
@@ -343,9 +336,7 @@ def run_test_queries_default(cluster: Cluster, bucket_name: str) -> None:
 
     for _ in range(3):
         try:
-            result = scope.query(
-                f"SELECT * FROM `{collection_name}` WHERE id > 0"
-            )
+            result = scope.query(f"SELECT * FROM `{collection_name}` WHERE id > 0")
             list(result)
         except Exception:
             pass
@@ -365,7 +356,9 @@ def run_test_queries_default(cluster: Cluster, bucket_name: str) -> None:
         pass
 
     try:
-        result = scope.query(f"SELECT * FROM `{collection_name}` ORDER BY META().id LIMIT 20")
+        result = scope.query(
+            f"SELECT * FROM `{collection_name}` ORDER BY META().id LIMIT 20"
+        )
         list(result)
     except Exception:
         pass

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -15,7 +15,6 @@ from tools import TOOL_ANNOTATIONS, get_tools
 # Import utilities
 from utils import (
     ALLOWED_TRANSPORTS,
-    DEFAULT_CONFIRMATION_REQUIRED_TOOLS,
     DEFAULT_HOST,
     DEFAULT_LOG_LEVEL,
     DEFAULT_PORT,
@@ -217,11 +216,10 @@ async def app_lifespan(server: FastMCP) -> AsyncIterator[AppContext]:
     "--confirmation-required-tools",
     "confirmation_required_tools",
     envvar="CB_MCP_CONFIRMATION_REQUIRED_TOOLS",
-    default=DEFAULT_CONFIRMATION_REQUIRED_TOOLS,
+    default=None,
     help="Comma-separated tool names that require user confirmation before execution. "
-    "Also accepts a file path containing one tool name per line."
-    "Requires the MCP client to support elicitation. "
-    "Default: 'delete_document_by_id'.",
+    "Also accepts a file path containing one tool name per line. "
+    "Requires the MCP client to support elicitation.",
 )
 @click.version_option(package_name="couchbase-mcp-server")
 @click.pass_context

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -105,7 +105,6 @@ async def app_lifespan(server: FastMCP) -> AsyncIterator[AppContext]:
     settings = get_settings()
     read_only_mode = settings.get("read_only_mode", True)
     read_only_query_mode = settings.get("read_only_query_mode", True)
-    settings.get("confirmation_required_tools", set())
 
     # Note: We don't validate configuration here to allow tool discovery
     # Configuration will be validated when tools are actually used

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -150,19 +150,16 @@ async def app_lifespan(server: FastMCP) -> AsyncIterator[AppContext]:
 @click.option(
     "--ca-cert-path",
     envvar="CB_CA_CERT_PATH",
-    default=None,
     help="Path to the server trust store (CA certificate) file. The certificate at this path is used to verify the server certificate during the authentication process.",
 )
 @click.option(
     "--client-cert-path",
     envvar="CB_CLIENT_CERT_PATH",
-    default=None,
     help="Path to the client certificate file used for mTLS authentication.",
 )
 @click.option(
     "--client-key-path",
     envvar="CB_CLIENT_KEY_PATH",
-    default=None,
     help="Path to the client certificate key file used for mTLS authentication.",
 )
 @click.option(
@@ -216,7 +213,6 @@ async def app_lifespan(server: FastMCP) -> AsyncIterator[AppContext]:
     "--confirmation-required-tools",
     "confirmation_required_tools",
     envvar="CB_MCP_CONFIRMATION_REQUIRED_TOOLS",
-    default=None,
     help="Comma-separated tool names that require user confirmation before execution. "
     "Also accepts a file path containing one tool name per line. "
     "Requires the MCP client to support elicitation.",

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -105,7 +105,7 @@ async def app_lifespan(server: FastMCP) -> AsyncIterator[AppContext]:
     settings = get_settings()
     read_only_mode = settings.get("read_only_mode", True)
     read_only_query_mode = settings.get("read_only_query_mode", True)
-    confirmation_required_tools = settings.get("confirmation_required_tools", set())
+    settings.get("confirmation_required_tools", set())
 
     # Note: We don't validate configuration here to allow tool discovery
     # Configuration will be validated when tools are actually used

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -19,7 +19,6 @@ from .connection import (
 # Constants
 from .constants import (
     ALLOWED_TRANSPORTS,
-    DEFAULT_CONFIRMATION_REQUIRED_TOOLS,
     DEFAULT_HOST,
     DEFAULT_LOG_LEVEL,
     DEFAULT_PORT,
@@ -62,7 +61,6 @@ __all__ = [
     # Constants
     "MCP_SERVER_NAME",
     "DEFAULT_READ_ONLY_MODE",
-    "DEFAULT_CONFIRMATION_REQUIRED_TOOLS",
     "DEFAULT_TRANSPORT",
     "DEFAULT_LOG_LEVEL",
     "DEFAULT_HOST",

--- a/src/utils/constants.py
+++ b/src/utils/constants.py
@@ -15,10 +15,6 @@ NETWORK_TRANSPORTS_SDK_MAPPING = {
     "sse": "sse",
 }
 
-# Default tools that require user confirmation before execution (via MCP elicitation).
-# These are high-risk, destructive operations that warrant explicit user consent.
-DEFAULT_CONFIRMATION_REQUIRED_TOOLS = "delete_document_by_id"
-
 # Logging Configuration
 # Change this to DEBUG, WARNING, ERROR as needed
 DEFAULT_LOG_LEVEL = "INFO"

--- a/tests/test_confirmation_tools.py
+++ b/tests/test_confirmation_tools.py
@@ -23,7 +23,6 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
 from tools import TOOL_ANNOTATIONS, get_tools
 from utils.config import parse_tool_names
-from utils.constants import DEFAULT_CONFIRMATION_REQUIRED_TOOLS
 from utils.elicitation import (
     ConfirmationResult,
     _build_confirmation_message,
@@ -36,14 +35,10 @@ VALID_TOOL_NAMES = {tool.__name__ for tool in get_tools(read_only_mode=False)}
 class TestDefaultConfirmationRequiredTools:
     """Tests for default confirmation-required tools configuration."""
 
-    def test_default_value_includes_delete(self):
-        """Default constant should include delete tool for safety."""
-        assert "delete_document_by_id" in DEFAULT_CONFIRMATION_REQUIRED_TOOLS
-
-    def test_parse_default_value(self):
-        """Default string should parse into expected tool set."""
-        result = parse_tool_names(DEFAULT_CONFIRMATION_REQUIRED_TOOLS, VALID_TOOL_NAMES)
-        assert result == {"delete_document_by_id"}
+    def test_no_default_confirmation_tools(self):
+        """No tools should require confirmation by default."""
+        result = parse_tool_names(None, VALID_TOOL_NAMES)
+        assert result == set()
 
 
 class TestToolAnnotations:


### PR DESCRIPTION
This pull request removes the default requirement for user confirmation on the delete_document_by_id tool. The changes include updating the CLI argument defaults in mcp_server.py, removing the DEFAULT_CONFIRMATION_REQUIRED_TOOLS constant from the utilities, and adjusting the documentation and test suite accordingly. F