### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ An [MCP](https://modelcontextprotocol.io/) server implementation of Couchbase th
 
 <!-- mcp-name: io.github.Couchbase-Ecosystem/mcp-server-couchbase -->
 
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/couchbase-ecosystem-mcp-server-couchbase).
+
 ## Features/Tools
 
 ### Cluster setup & health tools


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/couchbase-ecosystem-mcp-server-couchbase).