### PR TITLE
fix: test_cluster_connection always reports failure due to nonexistent cluster.connected attribute

### DIFF
--- a/src/tools/server.py
+++ b/src/tools/server.py
@@ -64,13 +64,20 @@ def test_cluster_connection(
     """
     try:
         cluster = get_cluster_connection(ctx)
+        # Verify the cluster is actually responsive. The Python SDK's
+        # `Cluster` class does not expose a `.connected` attribute, so the
+        # previous `cluster.connected` read raised AttributeError on every
+        # call and was caught below as a bogus connection failure (#127).
+        # `cluster.ping()` is the documented health check and raises if
+        # the cluster is unreachable.
+        cluster.ping()
         bucket = None
         if bucket_name:
             bucket = connect_to_bucket(cluster, bucket_name)
 
         return {
             "status": "success",
-            "cluster_connected": cluster.connected,
+            "cluster_connected": True,
             "bucket_connected": bucket is not None,
             "bucket_name": bucket_name,
             "message": "Successfully connected to Couchbase cluster",

--- a/src/tools/server.py
+++ b/src/tools/server.py
@@ -64,20 +64,21 @@ def test_cluster_connection(
     """
     try:
         cluster = get_cluster_connection(ctx)
-        # Verify the cluster is actually responsive. The Python SDK's
-        # `Cluster` class does not expose a `.connected` attribute, so the
+        # The Python SDK's `Cluster` class does not expose a `.connected`
+        # attribute (verified against couchbase-python-client 4.6.0), so the
         # previous `cluster.connected` read raised AttributeError on every
         # call and was caught below as a bogus connection failure (#127).
-        # `cluster.ping()` is the documented health check and raises if
-        # the cluster is unreachable.
-        cluster.ping()
+        # `get_cluster_connection(ctx)` would already have raised if the
+        # cluster were unreachable, so a non-None cluster here means we are
+        # connected. This mirrors the existing check in
+        # `get_server_configuration_status` above (line 46).
         bucket = None
         if bucket_name:
             bucket = connect_to_bucket(cluster, bucket_name)
 
         return {
             "status": "success",
-            "cluster_connected": True,
+            "cluster_connected": cluster is not None,
             "bucket_connected": bucket is not None,
             "bucket_name": bucket_name,
             "message": "Successfully connected to Couchbase cluster",


### PR DESCRIPTION
## Summary

Fixes #127. `test_cluster_connection` returned a bogus `"'Cluster' object has no attribute 'connected'"` error on every call — the Couchbase Python SDK 4.6.0 `Cluster` class doesn't expose a `connected` attribute, so the `AttributeError` got caught by the broad `except Exception` block on line 78 and reported back as a connection failure. The reported error was the literal opposite of the truth: every other tool against the same connection (`get_buckets_in_cluster`, `run_sql_plus_plus_query`, schema discovery, etc.) worked fine.

## Fix

One-line change: replace `cluster.connected` with `cluster is not None`, mirroring the check that the sibling function `get_server_configuration_status` already uses on [line 46](https://github.com/Couchbase-Ecosystem/mcp-server-couchbase/blob/main/src/tools/server.py#L46) of the same file. By the time control reaches the success path, `get_cluster_connection(ctx)` has already succeeded — so a non-None reference is sufficient evidence we're connected. The existing `except Exception` block still covers the genuinely-unreachable case via `get_cluster_connection` raising.

## Notes

- Originally proposed `cluster.ping()` as a more robust check; switched to `cluster is not None` per @nithishr's review feedback (`ping()` does a network round-trip, which is unnecessary cost for this tool).
- PR #120 (Python 3.14 support) does not currently touch `src/tools/server.py` — verified against `4e009d8`. The buggy line is unchanged on that branch, so this fix is still needed independently of #120. Happy to close #128 if you'd rather fold the one-liner into #120 yourself.

## Impact

LLM agents (Google ADK, OpenAI Agents SDK, LangChain, Claude, etc.) commonly call `test_cluster_connection` as a preflight sanity check on the user's first question. They received the bogus "Failed to connect" response, took it at face value, and refused to do real work — even though every other tool was fully functional. After this fix, agent prompts no longer need to bake in `do not call test_cluster_connection` workarounds.

## Test plan

- [x] `uv run ruff check src/tools/server.py` — All checks passed
- [x] `uv run ruff format --check src/tools/server.py` — already formatted
- [ ] Call `test_cluster_connection` against a healthy local Couchbase cluster — expect `status: success, cluster_connected: True`
- [ ] Stop the cluster and call again — expect `status: error` with the actual SDK error from `get_cluster_connection` (no longer the misleading AttributeError text)