### PR TITLE
fix: test_cluster_connection attribute error

### DIFF
--- a/src/tools/server.py
+++ b/src/tools/server.py
@@ -70,7 +70,7 @@ def test_cluster_connection(
 
         return {
             "status": "success",
-            "cluster_connected": cluster.connected,
+            "cluster_connected": cluster is not None,
             "bucket_connected": bucket is not None,
             "bucket_name": bucket_name,
             "message": "Successfully connected to Couchbase cluster",


### PR DESCRIPTION
Fixes #127.

The Couchbase Python SDK Cluster object does not expose a `.connected` attribute. This results in an `AttributeError` when calling `test_cluster_connection`, which is then incorrectly reported as a connection failure.

This fix mirrors the logic used in `get_server_configuration_status` by checking if the cluster object is not None. Since `get_cluster_connection(ctx)` would have already raised an exception if the connection failed, a non-None cluster object indicates a successful connection at this point.