### PR TITLE
fix: add missing checkout step in deploy job of GitHub Actions workflow

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -56,6 +56,9 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
       - name: Download build artifact
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
* Add an explicit actions/checkout@v4 step to the deploy job before downloading the build artifact.