### PR TITLE
fix(ci): add pages and id-token permissions to deploy job

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -55,6 +55,11 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -66,6 +71,7 @@ jobs:
           path: website/build
 
       - name: Deploy to GitHub Pages
+        id: deployment
         uses: JamesIves/github-pages-deploy-action@v4
         with:
           folder: website/build


### PR DESCRIPTION
## Problem

After the Google Analytics PR (#134) was merged on April 15, the live site at `mcp-server.couchbase.com` continued serving the April 13 build — without the GTM/GA4 scripts.

**Root cause:** GitHub Pages is configured in workflow mode (`build_type: workflow`). In this mode, pushing to the `gh-pages` branch alone is not enough — the workflow must also have `pages: write` and `id-token: write` permissions so `JamesIves/github-pages-deploy-action` can create an official GitHub Pages deployment via the API. Without these permissions, the branch gets updated but no new Pages deployment is created, so the live site stays on the old build.

Evidence:
- `gh api repos/.../pages` → `"build_type": "workflow"`
- Last Pages deployment: April 13 (pre-analytics)
- April 15 JamesIves run log: pushed to `gh-pages` successfully, but no Pages deployment record created

## Fix

Add `pages: write` + `id-token: write` to the deploy job and declare the `github-pages` environment so JamesIves creates a proper Pages deployment.

## After merging

Once merged, manually trigger the workflow via **Actions → Deploy Docs → Run workflow** to redeploy the current build (which already has GTM-MVPNN2 + G-CVKKEY0D6B) to production.