### PR TITLE
feat(docs): add OneTrust cookie consent banner

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -32,6 +32,23 @@ const config = {
     locales: ["en"],
   },
 
+  headTags: [
+    {
+      tagName: "script",
+      attributes: {
+        src: "https://cdn.cookielaw.org/scripttemplates/otSDKStub.js",
+        type: "text/javascript",
+        charset: "UTF-8",
+        "data-domain-script": "748511ff-10bf-44bf-88b8-36382e5b5fd9",
+      },
+    },
+    {
+      tagName: "script",
+      attributes: { type: "text/javascript" },
+      innerHTML: "function OptanonWrapper() {}",
+    },
+  ],
+
   presets: [
     [
       "classic",


### PR DESCRIPTION
## Summary

Adds the OneTrust cookie consent banner to the Docusaurus site, as required by legal when Google Tag Manager is in use.

Per James Oquendo (Couchbase web team) in Slack:
> "if you are going to add tag manager to the websites, then there is a legal requirement to add the Cookie banner. Please add the following to the headers ASAP."

- OneTrust domain script ID: `748511ff-10bf-44bf-88b8-36382e5b5fd9` (couchbase.com property)
- Follows the same pattern as other Couchbase Docusaurus sites (cbl-ionic-docs, couchbase-ruby-orm)
- Build verified locally ✅