### PR TITLE
Server configuration tooling

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,6 +94,7 @@ mcp-server-couchbase/
 │   │   └── static.py                              # StaticClusterProvider used by mcp_server.py
 │   └── cb_mcp/                                    # Reusable Python package shared with other implementations
 │       ├── __init__.py                            # Package marker
+│       ├── tool_registration.py                   # Shared tool preparation for MCP server: parse, filter, wrap with confirmation
 │       ├── core/                                  # Host-agnostic contracts (ClusterProvider, ...)
 │       │   ├── __init__.py
 │       │   └── contracts.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "couchbase-mcp-server"
-version = "0.8.0-alpha3"
+version = "0.8.0-alpha4"
 description = "Couchbase MCP Server - The Developer Data Platform for Critical Applications in Our AI World"
 readme = "README.md"
 requires-python = ">=3.10,<3.14"

--- a/src/cb_mcp/core/contracts.py
+++ b/src/cb_mcp/core/contracts.py
@@ -38,8 +38,13 @@ class ClusterProvider(Protocol):
         """Provider-specific configuration suitable for status reporting.
 
         Must not include secrets — return ``_configured`` booleans instead.
+        Returned keys are merged into the top-level ``configuration`` dict of
+        ``get_server_configuration_status``; implementations must not reuse
+        server-level key names (``read_only_mode``, ``read_only_query_mode``,
+        ``disabled_tools``, ``confirmation_required_tools``) since those are
+        owned by the server and would silently override any provider value.
         Implementations may use ``ctx`` to return per-caller configuration
-        (e.g., per-API-key in managed hosts) or ignore it (static hosts).
+        (e.g., per-API-key in managed implementations) or ignore it (static implementations).
         """
         ...
 
@@ -47,6 +52,6 @@ class ClusterProvider(Protocol):
         """True if a cluster is currently open for this caller.
 
         Implementations may use ``ctx`` to check per-caller connection state
-        (e.g., per-principal cache entry) or ignore it (static hosts).
+        (e.g., per-principal cache entry) or ignore it (static implementations).
         """
         ...

--- a/src/cb_mcp/core/contracts.py
+++ b/src/cb_mcp/core/contracts.py
@@ -9,7 +9,8 @@ both hosts reach a Couchbase cluster through the same
 interface.
 """
 
-from typing import Protocol, runtime_checkable
+from collections.abc import Mapping
+from typing import Any, Protocol, runtime_checkable
 
 from acouchbase.cluster import Cluster
 from fastmcp import Context
@@ -31,4 +32,21 @@ class ClusterProvider(Protocol):
 
     async def close(self) -> None:
         """Release any clusters held by this provider and perform cleanup."""
+        ...
+
+    async def get_configuration(self, ctx: Context) -> Mapping[str, Any]:
+        """Provider-specific configuration suitable for status reporting.
+
+        Must not include secrets — return ``_configured`` booleans instead.
+        Implementations may use ``ctx`` to return per-caller configuration
+        (e.g., per-API-key in managed hosts) or ignore it (static hosts).
+        """
+        ...
+
+    async def is_connected(self, ctx: Context) -> bool:
+        """True if a cluster is currently open for this caller.
+
+        Implementations may use ``ctx`` to check per-caller connection state
+        (e.g., per-principal cache entry) or ignore it (static hosts).
+        """
         ...

--- a/src/cb_mcp/tool_registration.py
+++ b/src/cb_mcp/tool_registration.py
@@ -1,0 +1,74 @@
+"""
+Tool registration orchestration shared across MCP implementations.
+"""
+
+import logging
+from collections.abc import Callable
+
+from .tools import get_tools
+from .utils.config import parse_tool_names
+from .utils.constants import MCP_SERVER_NAME
+from .utils.elicitation import wrap_with_confirmation
+
+logger = logging.getLogger(f"{MCP_SERVER_NAME}.tool_registration")
+
+
+def prepare_tools_for_registration(
+    read_only_mode: bool,
+    disabled_tools: str | None,
+    confirmation_required_tools: str | None,
+) -> tuple[list[Callable], set[str], set[str]]:
+    """Prepare final tool list and confirmation configuration for registration.
+
+    Loads the shared cb_mcp tools, parses the disabled and confirmation lists,
+    filters disabled tools out, and wraps confirmation-required tools with
+    elicitation. The same orchestration is reused by every cb_mcp host.
+    """
+    # When read_only_mode is True, KV write tools are not loaded.
+    tools = get_tools(read_only_mode=read_only_mode)
+
+    loaded_tool_names = {tool.__name__ for tool in tools}
+    disabled_tool_names = parse_tool_names(disabled_tools, loaded_tool_names)
+
+    if disabled_tool_names:
+        logger.info(
+            f"Disabled {len(disabled_tool_names)} tool(s): {sorted(disabled_tool_names)}"
+        )
+
+    configured_confirmation_tool_names = parse_tool_names(
+        confirmation_required_tools, loaded_tool_names
+    )
+
+    if configured_confirmation_tool_names:
+        logger.info(
+            f"Confirmation required for {len(configured_confirmation_tool_names)} tool(s): "
+            f"{sorted(configured_confirmation_tool_names)}"
+        )
+
+    enabled_tools = [tool for tool in tools if tool.__name__ not in disabled_tool_names]
+
+    # Apply confirmation only to tools that are actually active.
+    active_tool_names = {tool.__name__ for tool in enabled_tools}
+    active_confirmation_tool_names = (
+        configured_confirmation_tool_names & active_tool_names
+    )
+
+    skipped_confirmation_tool_names = (
+        configured_confirmation_tool_names - active_tool_names
+    )
+    if skipped_confirmation_tool_names:
+        logger.info(
+            "Skipped confirmation for unavailable tool(s): "
+            f"{sorted(skipped_confirmation_tool_names)}"
+        )
+
+    final_tools = [
+        (
+            wrap_with_confirmation(tool)
+            if tool.__name__ in active_confirmation_tool_names
+            else tool
+        )
+        for tool in enabled_tools
+    ]
+
+    return final_tools, configured_confirmation_tool_names, disabled_tool_names

--- a/src/cb_mcp/tools/server.py
+++ b/src/cb_mcp/tools/server.py
@@ -26,15 +26,19 @@ async def get_server_configuration_status(ctx: Context) -> dict[str, Any]:
     settings = get_settings(ctx)
     provider = get_cluster_provider(ctx)
 
+    provider_config = (
+        await provider.get_configuration(ctx) if provider is not None else {}
+    )
+
+    # Server-level keys are spread last so they always reflect what the server
+    # actually enforces, even if a provider returns overlapping keys.
     configuration = {
+        **provider_config,
         "read_only_mode": settings.get("read_only_mode", True),
         "read_only_query_mode": settings.get("read_only_query_mode", True),
         "disabled_tools": sorted(settings.get("disabled_tools", set())),
         "confirmation_required_tools": sorted(
             settings.get("confirmation_required_tools", set())
-        ),
-        "provider": (
-            await provider.get_configuration(ctx) if provider is not None else {}
         ),
     }
 

--- a/src/cb_mcp/tools/server.py
+++ b/src/cb_mcp/tools/server.py
@@ -24,27 +24,23 @@ async def get_server_configuration_status(ctx: Context) -> dict[str, Any]:
     This tool can be used to verify if the server is running and check the configuration.
     """
     settings = get_settings(ctx)
+    provider = get_cluster_provider(ctx)
 
-    # Don't expose sensitive information like passwords
     configuration = {
-        "connection_string": settings.get("connection_string", "Not set"),
-        "username": settings.get("username", "Not set"),
         "read_only_mode": settings.get("read_only_mode", True),
         "read_only_query_mode": settings.get("read_only_query_mode", True),
         "disabled_tools": sorted(settings.get("disabled_tools", set())),
         "confirmation_required_tools": sorted(
             settings.get("confirmation_required_tools", set())
         ),
-        "password_configured": bool(settings.get("password")),
-        "ca_cert_path_configured": bool(settings.get("ca_cert_path")),
-        "client_cert_path_configured": bool(settings.get("client_cert_path")),
-        "client_key_path_configured": bool(settings.get("client_key_path")),
+        "provider": (
+            await provider.get_configuration(ctx) if provider is not None else {}
+        ),
     }
 
-    provider = get_cluster_provider(ctx)
     connection_status = {
-        "cluster_connected": bool(
-            provider is not None and getattr(provider, "is_connected", False)
+        "cluster_connected": (
+            await provider.is_connected(ctx) if provider is not None else False
         ),
     }
 

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -3,7 +3,7 @@ Couchbase MCP Server
 """
 
 import logging
-from collections.abc import AsyncIterator, Callable
+from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 
 import click
@@ -11,7 +11,8 @@ from fastmcp import FastMCP
 from fastmcp.tools import FunctionTool
 
 # Reusable tools and utilities from the cb_mcp package
-from cb_mcp.tools import TOOL_ANNOTATIONS, get_tools
+from cb_mcp.tool_registration import prepare_tools_for_registration
+from cb_mcp.tools import TOOL_ANNOTATIONS
 from cb_mcp.utils import (
     ALLOWED_TRANSPORTS,
     DEFAULT_HOST,
@@ -23,8 +24,6 @@ from cb_mcp.utils import (
     NETWORK_TRANSPORTS,
     NETWORK_TRANSPORTS_SDK_MAPPING,
     AppContext,
-    parse_tool_names,
-    wrap_with_confirmation,
 )
 
 # Standalone-host provider implementation
@@ -37,66 +36,6 @@ logging.basicConfig(
 )
 
 logger = logging.getLogger(MCP_SERVER_NAME)
-
-
-def prepare_tools_for_registration(
-    read_only_mode: bool,
-    disabled_tools: str | None,
-    confirmation_required_tools: str | None,
-) -> tuple[list[Callable], set[str], set[str]]:
-    """Prepare final tool list and confirmation configuration for registration."""
-    # Get tools based on mode settings
-    # When read_only_mode is True, KV write tools are not loaded
-    tools = get_tools(read_only_mode=read_only_mode)
-
-    # Parse and validate disabled tools from CLI/environment variable
-    loaded_tool_names = {tool.__name__ for tool in tools}
-    disabled_tool_names = parse_tool_names(disabled_tools, loaded_tool_names)
-
-    if disabled_tool_names:
-        logger.info(
-            f"Disabled {len(disabled_tool_names)} tool(s): {sorted(disabled_tool_names)}"
-        )
-
-    # Parse and validate confirmation-required tools
-    configured_confirmation_tool_names = parse_tool_names(
-        confirmation_required_tools, loaded_tool_names
-    )
-
-    if configured_confirmation_tool_names:
-        logger.info(
-            f"Confirmation required for {len(configured_confirmation_tool_names)} tool(s): "
-            f"{sorted(configured_confirmation_tool_names)}"
-        )
-
-    # Filter out disabled tools
-    enabled_tools = [tool for tool in tools if tool.__name__ not in disabled_tool_names]
-
-    # Apply confirmation to tools that are currently active.
-    active_tool_names = {tool.__name__ for tool in enabled_tools}
-    active_confirmation_tool_names = (
-        configured_confirmation_tool_names & active_tool_names
-    )
-
-    skipped_confirmation_tool_names = (
-        configured_confirmation_tool_names - active_tool_names
-    )
-    if skipped_confirmation_tool_names:
-        logger.info(
-            "Skipped confirmation for unavailable tool(s): "
-            f"{sorted(skipped_confirmation_tool_names)}"
-        )
-
-    final_tools = [
-        (
-            wrap_with_confirmation(tool)
-            if tool.__name__ in active_confirmation_tool_names
-            else tool
-        )
-        for tool in enabled_tools
-    ]
-
-    return final_tools, configured_confirmation_tool_names, disabled_tool_names
 
 
 @click.command()

--- a/src/providers/static.py
+++ b/src/providers/static.py
@@ -87,5 +87,10 @@ class StaticClusterProvider:
     async def is_connected(
         self, ctx: Context
     ) -> bool:  # ctx unused; one cluster shared across callers
-        """True once get_cluster has successfully opened the shared cluster."""
+        """True if a cluster is currently open for this caller.
+        Reflects cache state at the moment of the call. Does not wait for
+        in-flight connection attempts to settle — concurrent tools that are
+        mid-connect will not yet be reflected here. Callers that want a
+        definitive answer should connect explicitly via test_cluster_connection.
+        """
         return self._cluster is not None

--- a/src/providers/static.py
+++ b/src/providers/static.py
@@ -70,7 +70,22 @@ class StaticClusterProvider:
             await cluster.close()
             self._cluster = None
 
-    @property
-    def is_connected(self) -> bool:
-        """True once get_cluster has successfully opened a connection."""
+    async def get_configuration(
+        self, ctx: Context
+    ) -> Mapping[str, Any]:  # ctx unused; settings come from init
+        """Return credential-related configuration. Never includes secrets."""
+        s = self._settings
+        return {
+            "connection_string": s.get("connection_string", "Not set"),
+            "username": s.get("username", "Not set"),
+            "password_configured": bool(s.get("password")),
+            "ca_cert_path_configured": bool(s.get("ca_cert_path")),
+            "client_cert_path_configured": bool(s.get("client_cert_path")),
+            "client_key_path_configured": bool(s.get("client_key_path")),
+        }
+
+    async def is_connected(
+        self, ctx: Context
+    ) -> bool:  # ctx unused; one cluster shared across callers
+        """True once get_cluster has successfully opened the shared cluster."""
         return self._cluster is not None

--- a/tests/test_server_tools.py
+++ b/tests/test_server_tools.py
@@ -38,17 +38,14 @@ async def test_get_server_configuration_status() -> None:
 
         # Configuration should be present but not expose the password
         config = payload.get("configuration", {})
+        assert "connection_string" in config
+        assert "username" in config
         assert "disabled_tools" in config
         assert "confirmation_required_tools" in config
         assert isinstance(config["disabled_tools"], list)
         assert isinstance(config["confirmation_required_tools"], list)
-
-        # Provider-specific configuration is nested under "provider"
-        provider_config = config.get("provider", {})
-        assert "connection_string" in provider_config
-        assert "username" in provider_config
-        assert "password_configured" in provider_config
-        assert "password" not in provider_config  # password should NOT be exposed
+        assert "password_configured" in config
+        assert "password" not in config  # password should NOT be exposed
 
 
 @pytest.mark.asyncio

--- a/tests/test_server_tools.py
+++ b/tests/test_server_tools.py
@@ -38,14 +38,17 @@ async def test_get_server_configuration_status() -> None:
 
         # Configuration should be present but not expose the password
         config = payload.get("configuration", {})
-        assert "connection_string" in config
-        assert "username" in config
         assert "disabled_tools" in config
         assert "confirmation_required_tools" in config
         assert isinstance(config["disabled_tools"], list)
         assert isinstance(config["confirmation_required_tools"], list)
-        assert "password_configured" in config
-        assert "password" not in config  # password should NOT be exposed
+
+        # Provider-specific configuration is nested under "provider"
+        provider_config = config.get("provider", {})
+        assert "connection_string" in provider_config
+        assert "username" in provider_config
+        assert "password_configured" in provider_config
+        assert "password" not in provider_config  # password should NOT be exposed
 
 
 @pytest.mark.asyncio

--- a/tests/test_tool_registration.py
+++ b/tests/test_tool_registration.py
@@ -2,7 +2,7 @@
 Unit tests for prepare_tools_for_registration — tool disabling and confirmation wrapping.
 """
 
-from mcp_server import prepare_tools_for_registration
+from cb_mcp.tool_registration import prepare_tools_for_registration
 
 
 class TestPrepareToolsDisabling:

--- a/uv.lock
+++ b/uv.lock
@@ -254,7 +254,7 @@ wheels = [
 
 [[package]]
 name = "couchbase-mcp-server"
-version = "0.8.0a3"
+version = "0.8.0a4"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
* Refactored Tool Registration: Moved the tool registration orchestration logic from the main server file to a shared cb_mcp.tool_registration module to improve code reuse.
* Enhanced Provider Contracts: Updated the ClusterProvider interface to include get_configuration and is_connected methods, allowing for cleaner status reporting.
* Improved Configuration Reporting: Restructured the server configuration status tool to nest provider-specific details under a dedicated provider key, enhancing clarity and organization.