### PR TITLE
Build docs for all PRs

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -7,8 +7,6 @@ on:
       - 'website/**'
   pull_request:
     types: [opened, synchronize, reopened, closed]
-    paths:
-      - 'website/**'
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
This PR updates the docs workflow so pull requests always build documentation, regardless of which files changed.

Changes:

* Removed the website/** path filter from pull_request events.
* Keeps push builds limited to website changes and preserves manual dispatch behavior.