### PR TITLE
Update repository links to use the correct GitHub organization slug

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,11 +15,11 @@ Thank you for your interest in contributing to the Couchbase MCP Server! This gu
 
 ```bash
 # Clone the repository
-git clone https://github.com/Couchbase-Ecosystem/mcp-server-couchbase.git
+git clone https://github.com/couchbase/mcp-server-couchbase.git
 cd mcp-server-couchbase
 ```
 
-**Note:** External contributors do not have commit permissions on the main repository. [Fork the repo](https://github.com/Couchbase-Ecosystem/mcp-server-couchbase/fork) to your own GitHub account and clone your fork instead of this repo.
+**Note:** External contributors do not have commit permissions on the main repository. [Fork the repo](https://github.com/couchbase/mcp-server-couchbase/fork) to your own GitHub account and clone your fork instead of this repo.
 
 ```bash
 # Install dependencies (including development tools)
@@ -81,7 +81,7 @@ Our Ruff configuration includes:
 3. **Add proper logging**: Use the hierarchical logging system
 4. **Handle errors gracefully**: Provide helpful error messages
 5. **Consider read-only mode**: If your tool modifies data, respect `read_only_mode` settings
-6. **Update documentation**: Update README.md, DOCKER.md, and the docs site (in the [Couchbase-Ecosystem/mcp-server-couchbase-docs](https://github.com/Couchbase-Ecosystem/mcp-server-couchbase-docs) repo, under `versioned_docs/version-<X>/`) if adding user-facing features
+6. **Update documentation**: Update README.md, DOCKER.md, and the docs site (in the [couchbase/mcp-server-couchbase-docs](https://github.com/couchbase/mcp-server-couchbase-docs) repo, under `versioned_docs/version-<X>/`) if adding user-facing features
 
 ## 🏗️ Project Structure
 

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -4,9 +4,9 @@ Pre-built images for the [Couchbase](https://www.couchbase.com/) MCP Server.
 
 A Model Context Protocol (MCP) server that allows AI agents to interact with Couchbase databases.
 
-GitHub Repo: <https://github.com/Couchbase-Ecosystem/mcp-server-couchbase>
+GitHub Repo: <https://github.com/couchbase/mcp-server-couchbase>
 
-Dockerfile: <https://github.com/Couchbase-Ecosystem/mcp-server-couchbase/blob/main/Dockerfile>
+Dockerfile: <https://github.com/couchbase/mcp-server-couchbase/blob/main/Dockerfile>
 
 Documentation: <https://mcp-server.couchbase.com>
 
@@ -99,7 +99,7 @@ Add the configuration specified below to the MCP configuration in your MCP clien
 
 ### Environment Variables
 
-The detailed explanation for the environment variables can be found on the [GitHub Repo](https://github.com/Couchbase-Ecosystem/mcp-server-couchbase?tab=readme-ov-file#additional-configuration-for-mcp-server).
+The detailed explanation for the environment variables can be found on the [GitHub Repo](https://github.com/couchbase/mcp-server-couchbase?tab=readme-ov-file#additional-configuration-for-mcp-server).
 
 | Variable                             | Description                                                                                                                                              | Default                                                        |
 | ------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ LABEL org.opencontainers.image.revision="${GIT_COMMIT_HASH}" \
     org.opencontainers.image.created="${BUILD_DATE}" \
     org.opencontainers.image.title="MCP Server Couchbase" \
     org.opencontainers.image.description="Model Context Protocol server for Couchbase" \
-    org.opencontainers.image.source="https://github.com/Couchbase-Ecosystem/mcp-server-couchbase"\
+    org.opencontainers.image.source="https://github.com/couchbase/mcp-server-couchbase"\
     io.modelcontextprotocol.server.name="io.github.Couchbase-Ecosystem/mcp-server-couchbase"
 
 # Create non-root user

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ The MCP server can be run from the source using this repository.
 #### Clone the repository to your local machine
 
 ```bash
-git clone https://github.com/Couchbase-Ecosystem/mcp-server-couchbase.git
+git clone https://github.com/couchbase/mcp-server-couchbase.git
 ```
 
 #### Server Configuration using Source for MCP Clients
@@ -679,7 +679,7 @@ uv run pytest tests/ -v
 
 We welcome contributions from the community! Whether you want to fix bugs, add features, or improve documentation, your help is appreciated.
 
-If you need help, have found a bug, or want to contribute improvements, the best place to do that is right here — by [opening a GitHub issue](https://github.com/Couchbase-Ecosystem/mcp-server-couchbase/issues).
+If you need help, have found a bug, or want to contribute improvements, the best place to do that is right here — by [opening a GitHub issue](https://github.com/couchbase/mcp-server-couchbase/issues).
 
 ### For Developers
 
@@ -697,7 +697,7 @@ If you're interested in contributing code or setting up a development environmen
 
 ```bash
 # Clone and setup
-git clone https://github.com/Couchbase-Ecosystem/mcp-server-couchbase.git
+git clone https://github.com/couchbase/mcp-server-couchbase.git
 cd mcp-server-couchbase
 
 # Install with development dependencies

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -138,7 +138,7 @@ Once the tag is pushed, three GitHub Actions workflows run **in parallel/sequenc
 
 Check that all three workflows succeeded:
 
-- [GitHub Actions](https://github.com/Couchbase-Ecosystem/mcp-server-couchbase/actions)
+- [GitHub Actions](https://github.com/couchbase/mcp-server-couchbase/actions)
 
 Verify the release is available on:
 


### PR DESCRIPTION
* Updated GitHub Actions, clone, and issue links in docs from Couchbase-Ecosystem to couchbase.
* Updated Docker OCI image org.opencontainers.image.source label to the new repository URL.
* Updated contribution docs to reference the couchbase org for the main repo and docs repo.