### PR TITLE
Streamable HTTP Integration Tests should use remote server

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -213,16 +213,40 @@ jobs:
           SERVER_PID=$!
           echo "SERVER_PID=$SERVER_PID" >> $GITHUB_ENV
 
-          # Wait for server to be ready (check if port is listening)
-          echo "Waiting for HTTP server to be ready..."
-          for i in {1..30}; do
-            if nc -z 127.0.0.1 8000 2>/dev/null; then
-              echo "HTTP server is ready"
-              break
-            fi
-            echo "Waiting for HTTP server... ($i/30)"
-            sleep 1
-          done
+          # Wait until the server can complete an MCP initialize — not just
+          # bind the port. `nc -z` returns true as soon as uvicorn opens the
+          # socket but before lifespan startup finishes, which races the
+          # first few tests. The probe below actually drives a session.
+          echo "Waiting for HTTP server to accept MCP initialize..."
+          uv run python - <<'PY'
+          import asyncio
+          import sys
+          from mcp import ClientSession
+          from mcp.client.streamable_http import streamable_http_client
+
+          URL = "http://127.0.0.1:8000/mcp"
+
+          async def probe() -> bool:
+              try:
+                  async with streamable_http_client(URL) as (r, w, _):
+                      async with ClientSession(r, w) as s:
+                          await asyncio.wait_for(s.initialize(), timeout=5)
+                          return True
+              except Exception as e:
+                  print(f"  not ready: {type(e).__name__}: {e}", flush=True)
+                  return False
+
+          async def main() -> None:
+              for _ in range(30):
+                  if await probe():
+                      print("HTTP server accepted MCP initialize.")
+                      return
+                  await asyncio.sleep(1)
+              print("HTTP server never accepted MCP initialize.", flush=True)
+              sys.exit(1)
+
+          asyncio.run(main())
+          PY
 
       - name: Run HTTP transport tests
         if: matrix.transport == 'http'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -206,6 +206,10 @@ jobs:
           CB_MCP_TRANSPORT: http
           CB_MCP_HOST: 127.0.0.1
           CB_MCP_PORT: 8000
+          # Match _build_env() so the standing server exposes the same tool
+          # registry the stdio leg gets — otherwise KV write tools are hidden
+          # (default is read-only=true) and ~12 cluster tests fail.
+          CB_MCP_READ_ONLY_MODE: "false"
           PYTHONPATH: src
         run: |
           echo "Starting MCP server with HTTP transport..."

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -23,6 +23,7 @@ from _test_env import (
     require_test_bucket,
 )
 from mcp import ClientSession, StdioServerParameters, stdio_client
+from mcp.client.streamable_http import streamable_http_client
 
 if TYPE_CHECKING:
     from typing import TextIO
@@ -34,6 +35,7 @@ __all__ = [
     "_build_env",
     "create_logging_test_session",
     "create_mcp_session",
+    "create_stdio_session",
     "ensure_list",
     "extract_payload",
     "get_test_bucket",
@@ -183,14 +185,50 @@ DEFAULT_TIMEOUT = int(os.getenv("CB_MCP_TEST_TIMEOUT", "120"))
 
 
 @asynccontextmanager
-async def create_mcp_session(
+async def create_mcp_session() -> AsyncIterator[ClientSession]:
+    """Create an MCP client session, transport chosen by the environment.
+
+    When ``MCP_SERVER_URL`` is set (the http-transport CI leg exports it
+    pointing at the standing server), connect over streamable-http and
+    reuse that shared server. Otherwise spawn a fresh stdio subprocess.
+
+    Tests that need a fresh server *process* per test — to apply env-var
+    overrides like ``CB_MCP_READ_ONLY_MODE`` or ``CB_MCP_DISABLED_TOOLS``
+    — must use :func:`create_stdio_session` instead, which always spawns
+    and accepts ``env_overrides``. Per-test env can't be applied to the
+    shared HTTP server.
+    """
+    server_url = os.getenv("MCP_SERVER_URL")
+    if server_url:
+        async with asyncio.timeout(DEFAULT_TIMEOUT):
+            async with streamable_http_client(server_url) as (
+                read_stream,
+                write_stream,
+                _,
+            ):
+                async with ClientSession(read_stream, write_stream) as session:
+                    await session.initialize()
+                    yield session
+        return
+
+    async with create_stdio_session() as session:
+        yield session
+
+
+@asynccontextmanager
+async def create_stdio_session(
     env_overrides: dict[str, str] | None = None,
 ) -> AsyncIterator[ClientSession]:
-    """Create a fresh MCP client session connected to the server over stdio.
+    """Spawn a fresh stdio MCP server subprocess and connect to it.
 
-    Optional ``env_overrides`` are merged onto the environment passed to the
-    spawned server process, letting individual tests opt into things like
-    ``CB_MCP_READ_ONLY_MODE`` or ``CB_MCP_DISABLED_TOOLS``.
+    Use this when a test needs server-process-private state — typically
+    because it sets ``CB_MCP_READ_ONLY_MODE``, ``CB_MCP_DISABLED_TOOLS``,
+    or another env var that's read at server startup. These can't be
+    applied to a shared HTTP server, so this helper bypasses transport
+    routing and always spawns.
+
+    ``env_overrides`` are merged onto the spawned process's environment
+    after the standard ``_build_env()`` setup.
     """
     env = _build_env()
     if env_overrides:

--- a/tests/integration/test_read_only_and_disabled_tools.py
+++ b/tests/integration/test_read_only_and_disabled_tools.py
@@ -12,7 +12,7 @@ these tests verify they're wired correctly through the server entry point.
 from __future__ import annotations
 
 import pytest
-from conftest import create_mcp_session, extract_payload
+from conftest import create_stdio_session, extract_payload
 
 KV_WRITE_TOOLS = {
     "upsert_document_by_id",
@@ -34,7 +34,7 @@ ALWAYS_AVAILABLE_TOOLS = {
 @pytest.mark.asyncio
 async def test_read_only_mode_filters_kv_write_tools() -> None:
     """READ_ONLY_MODE=true must hide every KV write tool from the registry."""
-    async with create_mcp_session(
+    async with create_stdio_session(
         env_overrides={"CB_MCP_READ_ONLY_MODE": "true"}
     ) as session:
         tools_response = await session.list_tools()
@@ -54,7 +54,7 @@ async def test_read_only_mode_filters_kv_write_tools() -> None:
 @pytest.mark.asyncio
 async def test_read_only_mode_reported_in_configuration_status() -> None:
     """get_server_configuration_status must reflect read-only mode."""
-    async with create_mcp_session(
+    async with create_stdio_session(
         env_overrides={"CB_MCP_READ_ONLY_MODE": "true"}
     ) as session:
         response = await session.call_tool(
@@ -72,16 +72,14 @@ async def test_read_only_mode_reported_in_configuration_status() -> None:
 @pytest.mark.asyncio
 async def test_write_mode_exposes_kv_write_tools() -> None:
     """READ_ONLY_MODE=false must expose every KV write tool."""
-    async with create_mcp_session(
+    async with create_stdio_session(
         env_overrides={"CB_MCP_READ_ONLY_MODE": "false"}
     ) as session:
         tools_response = await session.list_tools()
         tool_names = {tool.name for tool in tools_response.tools}
 
         missing = KV_WRITE_TOOLS - tool_names
-        assert not missing, (
-            f"KV write tools missing in write mode: {sorted(missing)}"
-        )
+        assert not missing, f"KV write tools missing in write mode: {sorted(missing)}"
 
 
 @pytest.mark.asyncio
@@ -89,7 +87,7 @@ async def test_disabled_tools_excluded_from_registry() -> None:
     """Tools named in CB_MCP_DISABLED_TOOLS must not be registered."""
     disabled = "list_indexes,get_buckets_in_cluster"
 
-    async with create_mcp_session(
+    async with create_stdio_session(
         env_overrides={"CB_MCP_DISABLED_TOOLS": disabled}
     ) as session:
         tools_response = await session.list_tools()
@@ -115,7 +113,7 @@ async def test_disabled_tools_reported_in_configuration_status() -> None:
     """get_server_configuration_status must surface the disabled-tools list."""
     disabled = "list_indexes,get_buckets_in_cluster"
 
-    async with create_mcp_session(
+    async with create_stdio_session(
         env_overrides={"CB_MCP_DISABLED_TOOLS": disabled}
     ) as session:
         response = await session.call_tool(
@@ -135,7 +133,7 @@ async def test_disabled_tools_reported_in_configuration_status() -> None:
 @pytest.mark.asyncio
 async def test_disabled_tools_invalid_names_ignored() -> None:
     """Unknown tool names in CB_MCP_DISABLED_TOOLS must be silently ignored."""
-    async with create_mcp_session(
+    async with create_stdio_session(
         env_overrides={
             "CB_MCP_DISABLED_TOOLS": "list_indexes,not_a_real_tool,definitely_fake"
         }
@@ -152,21 +150,20 @@ async def test_disabled_tools_invalid_names_ignored() -> None:
 @pytest.mark.asyncio
 async def test_calling_disabled_tool_fails() -> None:
     """A disabled tool must not be callable via the MCP session."""
-    async with create_mcp_session(
+    async with create_stdio_session(
         env_overrides={"CB_MCP_DISABLED_TOOLS": "get_buckets_in_cluster"}
     ) as session:
         response = await session.call_tool("get_buckets_in_cluster", arguments={})
 
         assert getattr(response, "isError", False), (
-            "Calling a disabled tool should produce an error response, "
-            f"got: {response}"
+            f"Calling a disabled tool should produce an error response, got: {response}"
         )
 
 
 @pytest.mark.asyncio
 async def test_read_only_mode_blocks_calling_write_tools() -> None:
     """A KV write tool must not be invokable when read-only mode is on."""
-    async with create_mcp_session(
+    async with create_stdio_session(
         env_overrides={"CB_MCP_READ_ONLY_MODE": "true"}
     ) as session:
         response = await session.call_tool(


### PR DESCRIPTION
Update integration test harness to route sessions over HTTP when MCP_SERVER_URL is provided, while introducing an always-spawn stdio helper for tests that need per-test env overrides; improve HTTP CI readiness probing.
