### PR TITLE
Release/0.8.0.post1

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   REGISTRY: docker.io
-  IMAGE_NAME: couchbaseecosystem/mcp-server-couchbase
+  IMAGE_NAME: couchbase/mcp-server
 
 jobs:
   docker:
@@ -86,6 +86,7 @@ jobs:
 
       - name: Update Docker Hub description
         if: github.ref_type == 'tag'
+        continue-on-error: true # Don't fail the workflow if this step fails
         uses: peter-evans/dockerhub-description@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/.github/workflows/update-mcp-registry.yml
+++ b/.github/workflows/update-mcp-registry.yml
@@ -145,5 +145,5 @@ jobs:
           VERSION: ${{ steps.version.outputs.version }}
         run: |
           echo "MCP Registry updated successfully for version $VERSION"
-          echo "Docker image: docker.io/couchbaseecosystem/mcp-server-couchbase:$VERSION"
+          echo "Docker image: docker.io/couchbase/mcp-server:$VERSION"
           echo "PyPI package: couchbase-mcp-server==$VERSION"

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -204,7 +204,7 @@ Lines starting with `#` are treated as comments and ignored.
         "CB_PASSWORD=password",
         "-e",
         "CB_MCP_DISABLED_TOOLS=/app/disabled_tools.txt",
-        "couchbase.docker.scarf.sh/couchbaseecosystem/mcp-server-couchbase:latest"
+        "docker.io/couchbase/mcp-server:latest"
       ]
     }
   }
@@ -276,7 +276,7 @@ When a listed tool is invoked:
         "CB_PASSWORD=password",
         "-e",
         "CB_MCP_CONFIRMATION_REQUIRED_TOOLS=delete_document_by_id,replace_document_by_id",
-        "couchbase.docker.scarf.sh/couchbaseecosystem/mcp-server-couchbase:latest"
+        "docker.io/couchbase/mcp-server:latest"
       ]
     }
   }

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -4,9 +4,9 @@ Pre-built images for the [Couchbase](https://www.couchbase.com/) MCP Server.
 
 A Model Context Protocol (MCP) server that allows AI agents to interact with Couchbase databases.
 
-GitHub Repo: <https://github.com/Couchbase-Ecosystem/mcp-server-couchbase>
+GitHub Repo: <https://github.com/couchbase/mcp-server-couchbase>
 
-Dockerfile: <https://github.com/Couchbase-Ecosystem/mcp-server-couchbase/blob/main/Dockerfile>
+Dockerfile: <https://github.com/couchbase/mcp-server-couchbase/blob/main/Dockerfile>
 
 Documentation: <https://mcp-server.couchbase.com>
 
@@ -90,7 +90,7 @@ Add the configuration specified below to the MCP configuration in your MCP clien
         "CB_USERNAME=<database_username>",
         "-e",
         "CB_PASSWORD=<database_password>",
-        "couchbase.docker.scarf.sh/couchbaseecosystem/mcp-server-couchbase:latest"
+        "docker.io/couchbase/mcp-server:latest"
       ]
     }
   }
@@ -99,7 +99,7 @@ Add the configuration specified below to the MCP configuration in your MCP clien
 
 ### Environment Variables
 
-The detailed explanation for the environment variables can be found on the [GitHub Repo](https://github.com/Couchbase-Ecosystem/mcp-server-couchbase?tab=readme-ov-file#additional-configuration-for-mcp-server).
+The detailed explanation for the environment variables can be found on the [GitHub Repo](https://github.com/couchbase/mcp-server-couchbase?tab=readme-ov-file#additional-configuration-for-mcp-server).
 
 | Variable                             | Description                                                                                                                                              | Default                                                        |
 | ------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
@@ -176,7 +176,7 @@ Lines starting with `#` are treated as comments and ignored.
         "CB_PASSWORD=password",
         "-e",
         "CB_MCP_DISABLED_TOOLS=upsert_document_by_id,delete_document_by_id",
-        "couchbase.docker.scarf.sh/couchbaseecosystem/mcp-server-couchbase:latest"
+        "docker.io/couchbase/mcp-server:latest"
       ]
     }
   }

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,8 +27,8 @@ LABEL org.opencontainers.image.revision="${GIT_COMMIT_HASH}" \
     org.opencontainers.image.created="${BUILD_DATE}" \
     org.opencontainers.image.title="MCP Server Couchbase" \
     org.opencontainers.image.description="Model Context Protocol server for Couchbase" \
-    org.opencontainers.image.source="https://github.com/Couchbase-Ecosystem/mcp-server-couchbase"\
-    io.modelcontextprotocol.server.name="io.github.Couchbase-Ecosystem/mcp-server-couchbase"
+    org.opencontainers.image.source="https://github.com/couchbase/mcp-server-couchbase"\
+    io.modelcontextprotocol.server.name="io.github.couchbase/mcp-server-couchbase"
 
 # Create non-root user
 RUN useradd --system --uid 1001 mcpuser

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ For full documentation, visit [mcp-server.couchbase.com](https://mcp-server.couc
   <img width="380" height="200" src="https://glama.ai/mcp/servers/@Couchbase-Ecosystem/mcp-server-couchbase/badge" alt="Couchbase Server MCP server" />
 </a>
 
-<!-- mcp-name: io.github.Couchbase-Ecosystem/mcp-server-couchbase -->
+<!-- mcp-name: io.github.couchbase/mcp-server-couchbase -->
 
 ## Features/Tools
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "couchbase-mcp-server"
-version = "0.8.0"
+version = "0.8.0.post1"
 description = "Couchbase MCP Server - The Developer Data Platform for Critical Applications in Our AI World"
 readme = "README.md"
 requires-python = ">=3.10,<3.15"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,9 +22,9 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/Couchbase-Ecosystem/mcp-server-couchbase"
+Homepage = "https://github.com/couchbase/mcp-server-couchbase"
 Documentation = "https://mcp-server.couchbase.com/"
-Issues = "https://github.com/Couchbase-Ecosystem/mcp-server-couchbase/issues"
+Issues = "https://github.com/couchbase/mcp-server-couchbase/issues"
 
 [project.scripts]
 couchbase-mcp-server = "mcp_server:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
 
 [project.urls]
 Homepage = "https://github.com/Couchbase-Ecosystem/mcp-server-couchbase"
-Documentation = "https://github.com/Couchbase-Ecosystem/mcp-server-couchbase#readme"
+Documentation = "https://mcp-server.couchbase.com/"
 Issues = "https://github.com/Couchbase-Ecosystem/mcp-server-couchbase/issues"
 
 [project.scripts]

--- a/server.json
+++ b/server.json
@@ -1,11 +1,12 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-  "name": "io.github.Couchbase-Ecosystem/mcp-server-couchbase",
+  "name": "io.github.couchbase/mcp-server-couchbase",
   "description": "Couchbase Model Context Protocol Server to interact with Couchbase clusters",
   "repository": {
-    "url": "https://github.com/Couchbase-Ecosystem/mcp-server-couchbase",
+    "url": "https://github.com/couchbase/mcp-server-couchbase",
     "source": "github"
   },
+  "websiteUrl": "https://mcp-server.couchbase.com/",
   "version": "0.8.0",
   "packages": [
     {
@@ -217,7 +218,7 @@
     },
     {
       "registryType": "oci",
-      "identifier": "docker.io/couchbaseecosystem/mcp-server-couchbase:0.8.0",
+      "identifier": "docker.io/couchbase/mcp-server:0.8.0",
       "transport": {
         "type": "stdio"
       },

--- a/server.json
+++ b/server.json
@@ -7,12 +7,12 @@
     "source": "github"
   },
   "websiteUrl": "https://mcp-server.couchbase.com/",
-  "version": "0.8.0",
+  "version": "0.8.0.post1",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "couchbase-mcp-server",
-      "version": "0.8.0",
+      "version": "0.8.0.post1",
       "transport": {
         "type": "stdio"
       },
@@ -218,7 +218,7 @@
     },
     {
       "registryType": "oci",
-      "identifier": "docker.io/couchbase/mcp-server:0.8.0",
+      "identifier": "docker.io/couchbase/mcp-server:0.8.0.post1",
       "transport": {
         "type": "stdio"
       },

--- a/uv.lock
+++ b/uv.lock
@@ -310,7 +310,7 @@ wheels = [
 
 [[package]]
 name = "couchbase-mcp-server"
-version = "0.8.0"
+version = "0.8.0.post1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
This PR prepares the 0.8.0.post1 release by updating version metadata across the Python project and MCP registry config, and by migrating repository/image identifiers from Couchbase-Ecosystem / couchbaseecosystem/mcp-server-couchbase to couchbase / couchbase/mcp-server.

Changes:

* Bump project version to 0.8.0.post1 across pyproject.toml, uv.lock, and server.json (including the OCI tag).
* Update MCP server identity + repository URLs to the new couchbase org and add websiteUrl in server.json.
* Rename the published Docker image target to docker.io/couchbase/mcp-server and update Docker docs/labels accordingly.
