### PR TITLE
Forward port fixes from 0.8.0.post1 for registry namespace switch to couchbase

### DIFF
--- a/.github/workflows/update-mcp-registry.yml
+++ b/.github/workflows/update-mcp-registry.yml
@@ -169,5 +169,5 @@ jobs:
           VERSION: ${{ steps.version.outputs.version }}
         run: |
           echo "MCP Registry updated successfully for version $VERSION"
-          echo "Docker image: docker.io/couchbaseecosystem/mcp-server-couchbase:$VERSION"
+          echo "Docker image: docker.io/couchbase/mcp-server:$VERSION"
           echo "PyPI package: couchbase-mcp-server==$VERSION"

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ LABEL org.opencontainers.image.revision="${GIT_COMMIT_HASH}" \
     org.opencontainers.image.title="MCP Server Couchbase" \
     org.opencontainers.image.description="Model Context Protocol server for Couchbase" \
     org.opencontainers.image.source="https://github.com/couchbase/mcp-server-couchbase"\
-    io.modelcontextprotocol.server.name="io.github.Couchbase-Ecosystem/mcp-server-couchbase"
+    io.modelcontextprotocol.server.name="io.github.couchbase/mcp-server-couchbase"
 
 # Create non-root user
 RUN useradd --system --uid 1001 mcpuser

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ For full documentation, visit [mcp-server.couchbase.com](https://mcp-server.couc
   <img width="380" height="200" src="https://glama.ai/mcp/servers/@Couchbase-Ecosystem/mcp-server-couchbase/badge" alt="Couchbase Server MCP server" />
 </a>
 
-<!-- mcp-name: io.github.Couchbase-Ecosystem/mcp-server-couchbase -->
+<!-- mcp-name: io.github.couchbase/mcp-server-couchbase -->
 
 ## Features/Tools
 
@@ -518,7 +518,7 @@ The server will be available on <http://localhost:8000/sse>. This can be used in
 
 ## Docker Image
 
-The MCP server can also be built and run as a Docker container. Prebuilt images can be found on [DockerHub](https://hub.docker.com/r/couchbaseecosystem/mcp-server-couchbase) or pulled via `docker pull couchbase.docker.scarf.sh/couchbaseecosystem/mcp-server-couchbase`.
+The MCP server can also be built and run as a Docker container. Prebuilt images can be found on [DockerHub](https://hub.docker.com/r/couchbase/mcp-server) or pulled via `docker pull docker.io/couchbase/mcp-server:latest`.
 
 Alternatively, we are part of the [Docker MCP Catalog](https://hub.docker.com/mcp/server/couchbase/overview).
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -59,7 +59,7 @@ Update the version in all locations:
      "packages": [
        {
          "registryType": "oci",
-         "identifier": "docker.io/couchbaseecosystem/mcp-server-couchbase:0.5.2",
+         "identifier": "docker.io/couchbase/mcp-server:0.5.2",
          ...
        }
      ]
@@ -147,7 +147,7 @@ Once the tag is pushed, three GitHub Actions workflows run **in parallel/sequenc
 
 2. **Docker Build**
    - Builds multi-architecture images (amd64, arm64)
-   - Pushes to Docker Hub as `couchbaseecosystem/mcp-server-couchbase`
+   - Pushes to Docker Hub as `couchbase/mcp-server`
    - Updates Docker Hub description
 
 3. **MCP Registry Update** (runs after Docker completes)
@@ -168,7 +168,7 @@ Check that all three workflows succeeded:
 Verify the release is available on:
 
 - [PyPI](https://pypi.org/project/couchbase-mcp-server/)
-- [Docker Hub](https://hub.docker.com/r/couchbaseecosystem/mcp-server-couchbase)
+- [Docker Hub](https://hub.docker.com/r/couchbase/mcp-server)
 - [MCP Registry](https://hub.docker.com/mcp/server/couchbase/overview)
 
 There is a delay between PyPI/Docker publish and MCP Registry update due to the images being built independently by Docker on a regular schedule. So check the MCP Registry the next day.
@@ -203,7 +203,7 @@ git push origin v0.5.2rc1
 **What gets published:**
 
 - PyPI: `couchbase-mcp-server==0.5.2rc1`
-- Docker Hub: `couchbaseecosystem/mcp-server-couchbase:0.5.2rc1`
+- Docker Hub: `couchbase/mcp-server:0.5.2rc1`
 - MCP Registry: version `0.5.2rc1`
 
 **If RC succeeds, release the final version:**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,9 +22,9 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/Couchbase-Ecosystem/mcp-server-couchbase"
-Documentation = "https://github.com/Couchbase-Ecosystem/mcp-server-couchbase#readme"
-Issues = "https://github.com/Couchbase-Ecosystem/mcp-server-couchbase/issues"
+Homepage = "https://github.com/couchbase/mcp-server-couchbase"
+Documentation = "https://mcp-server.couchbase.com/"
+Issues = "https://github.com/couchbase/mcp-server-couchbase/issues"
 
 [project.scripts]
 couchbase-mcp-server = "mcp_server:main"

--- a/server.json
+++ b/server.json
@@ -1,11 +1,12 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-  "name": "io.github.Couchbase-Ecosystem/mcp-server-couchbase",
+  "name": "io.github.couchbase/mcp-server-couchbase",
   "description": "Couchbase Model Context Protocol Server to interact with Couchbase clusters",
   "repository": {
-    "url": "https://github.com/Couchbase-Ecosystem/mcp-server-couchbase",
+    "url": "https://github.com/couchbase/mcp-server-couchbase",
     "source": "github"
   },
+  "websiteUrl": "https://mcp-server.couchbase.com/",
   "version": "0.8.1rc2",
   "packages": [
     {


### PR DESCRIPTION
Forward-ports the 0.8.0.post1 release fix to main by switching the MCP registry/server namespace and related metadata from Couchbase-Ecosystem to couchbase, and aligning Docker image/repo links accordingly.

Changes:

* Update MCP server registry name and repository URL to the couchbase GitHub org, and add the docs website URL.
* Rename Docker image references from couchbaseecosystem/mcp-server-couchbase to couchbase/mcp-server across release/docs/workflow output.
* Update project metadata URLs (pyproject) and MCP-related identifiers (README comment + Docker label).
