### PR TITLE
Move Validation to RestAPI path

### DIFF
--- a/src/cb_mcp/tools/index.py
+++ b/src/cb_mcp/tools/index.py
@@ -189,9 +189,8 @@ def list_indexes(
         # Validate parameters
         validate_filter_params(bucket_name, scope_name, collection_name, index_name)
 
-        # Get and validate connection settings
+        # Get connection settings
         settings = get_settings(ctx)
-        validate_connection_settings(settings)
 
         # Decide which path to use based on cluster version (via SDK).
         cluster = get_cluster_connection(ctx)
@@ -217,7 +216,11 @@ def list_indexes(
             logger.info(f"Found {len(indexes)} indexes via query service")
             return indexes
 
-        # Fallback / pre-8.x path: Index Service REST API
+        # Fallback / pre-8.x path: Index Service REST API.
+        # This path authenticates directly against the REST endpoint, so
+        # username/password (and connection_string) must be present.
+        validate_connection_settings(settings)
+
         logger.info(
             f"Fetching indexes from Index Service REST API for "
             f"bucket={bucket_name}, scope={scope_name}, "


### PR DESCRIPTION
This PR refines list_indexes so connection-setting validation (username/password/connection_string) is only enforced for the legacy Index Service REST API fallback path, not for the SDK/query-service path.

Changes:

* Removed unconditional validate_connection_settings(settings) from the top of list_indexes.
* Added validate_connection_settings(settings) immediately before the pre-8.x REST API fallback call.
* Clarified inline comments to explain why credentials are required for the REST endpoint path.