### PR TITLE
Add bucket management tools (create/update/delete/flush/compact/load_sample)

### DIFF
--- a/src/cb_mcp/tool_registration.py
+++ b/src/cb_mcp/tool_registration.py
@@ -5,7 +5,7 @@ Tool registration orchestration shared across MCP implementations.
 import logging
 from collections.abc import Callable
 
-from .tools import KV_WRITE_TOOLS, get_tools
+from .tools import ADMIN_WRITE_TOOLS, KV_WRITE_TOOLS, get_tools
 from .utils.config import parse_tool_names
 from .utils.constants import MCP_SERVER_NAME
 from .utils.elicitation import wrap_with_confirmation
@@ -23,6 +23,7 @@ def prepare_tools_for_registration(
     disabled_tools: str | None,
     confirmation_required_tools: str | None,
     enforce_scopes: bool = False,
+    admin_write_mode: bool = False,
 ) -> tuple[list[Callable], set[str], set[str]]:
     """Prepare final tool list and confirmation configuration for registration.
 
@@ -36,8 +37,9 @@ def prepare_tools_for_registration(
     (stdio / unauthenticated), so ``enforce_scopes`` only affects whether
     the wrapper is installed — not whether it does work per call.
     """
-    # When read_only_mode is True, KV write tools are not loaded.
-    tools = get_tools(read_only_mode=read_only_mode)
+    # When read_only_mode is True, KV write tools are not loaded. Admin write
+    # tools (index DDL, GSI settings) additionally require admin_write_mode.
+    tools = get_tools(read_only_mode=read_only_mode, admin_write_mode=admin_write_mode)
 
     loaded_tool_names = {tool.__name__ for tool in tools}
     disabled_tool_names = parse_tool_names(disabled_tools, loaded_tool_names)
@@ -74,7 +76,7 @@ def prepare_tools_for_registration(
             f"{sorted(skipped_confirmation_tool_names)}"
         )
 
-    write_tool_names = {fn.__name__ for fn in KV_WRITE_TOOLS}
+    write_tool_names = {fn.__name__ for fn in (*KV_WRITE_TOOLS, *ADMIN_WRITE_TOOLS)}
 
     final_tools: list[Callable] = []
     for tool in enabled_tools:

--- a/src/cb_mcp/tools/__init__.py
+++ b/src/cb_mcp/tools/__init__.py
@@ -12,6 +12,16 @@ from collections.abc import Callable
 
 from mcp.types import ToolAnnotations
 
+# Bucket management tools (create/update/delete/flush/compact/sample, write)
+from .bucket_admin import (
+    compact_bucket,
+    create_bucket,
+    delete_bucket,
+    flush_bucket,
+    load_sample_bucket,
+    update_bucket,
+)
+
 # Index tools
 from .index import get_index_advisor_recommendations, list_indexes
 
@@ -106,6 +116,12 @@ ADMIN_WRITE_TOOLS = [
     drop_index,
     build_deferred_indexes,
     admin_index_settings_set,
+    create_bucket,
+    update_bucket,
+    delete_bucket,
+    flush_bucket,
+    compact_bucket,
+    load_sample_bucket,
 ]
 
 # List of all tools for easy registration (kept for backward compatibility)
@@ -152,6 +168,13 @@ TOOL_ANNOTATIONS: dict[str, ToolAnnotations] = {
     "admin_index_settings_set": ToolAnnotations(
         destructiveHint=False, idempotentHint=True
     ),
+    # Bucket management tools (write)
+    "create_bucket": ToolAnnotations(idempotentHint=False),
+    "update_bucket": ToolAnnotations(destructiveHint=False, idempotentHint=True),
+    "delete_bucket": ToolAnnotations(destructiveHint=True, idempotentHint=True),
+    "flush_bucket": ToolAnnotations(destructiveHint=True, idempotentHint=True),
+    "compact_bucket": ToolAnnotations(destructiveHint=False, idempotentHint=False),
+    "load_sample_bucket": ToolAnnotations(destructiveHint=False, idempotentHint=True),
 }
 
 
@@ -203,6 +226,12 @@ __all__ = [
     "build_deferred_indexes",
     "admin_index_settings_get",
     "admin_index_settings_set",
+    "create_bucket",
+    "update_bucket",
+    "delete_bucket",
+    "flush_bucket",
+    "compact_bucket",
+    "load_sample_bucket",
     "get_cluster_health_and_services",
     "get_queries_not_selective",
     "get_queries_not_using_covering_index",

--- a/src/cb_mcp/tools/__init__.py
+++ b/src/cb_mcp/tools/__init__.py
@@ -15,6 +15,15 @@ from mcp.types import ToolAnnotations
 # Index tools
 from .index import get_index_advisor_recommendations, list_indexes
 
+# Index management tools (DDL + GSI settings, write)
+from .index_admin import (
+    admin_index_settings_get,
+    admin_index_settings_set,
+    build_deferred_indexes,
+    create_index,
+    drop_index,
+)
+
 # Key-Value tools
 from .kv import (
     delete_document_by_id,
@@ -68,6 +77,8 @@ READ_ONLY_TOOLS = [
     # Index tools
     get_index_advisor_recommendations,
     list_indexes,
+    # Index settings (read)
+    admin_index_settings_get,
     # Query performance analysis tools
     get_queries_not_selective,
     get_queries_not_using_covering_index,
@@ -84,6 +95,17 @@ KV_WRITE_TOOLS = [
     insert_document_by_id,
     replace_document_by_id,
     delete_document_by_id,
+]
+
+# Admin write tools - loaded only when read_only_mode is False AND
+# admin_write_mode is True. These mutate cluster structure (index DDL) or
+# cluster-wide index settings, a strictly higher privilege than data writes,
+# so they gate behind a second, independent flag.
+ADMIN_WRITE_TOOLS = [
+    create_index,
+    drop_index,
+    build_deferred_indexes,
+    admin_index_settings_set,
 ]
 
 # List of all tools for easy registration (kept for backward compatibility)
@@ -121,20 +143,39 @@ TOOL_ANNOTATIONS: dict[str, ToolAnnotations] = {
     "insert_document_by_id": ToolAnnotations(idempotentHint=True),
     "replace_document_by_id": ToolAnnotations(idempotentHint=True),
     "delete_document_by_id": ToolAnnotations(destructiveHint=True, idempotentHint=True),
+    # Index management tools (write)
+    "create_index": ToolAnnotations(idempotentHint=False),
+    "drop_index": ToolAnnotations(destructiveHint=True, idempotentHint=True),
+    "build_deferred_indexes": ToolAnnotations(idempotentHint=True),
+    # Index settings
+    "admin_index_settings_get": ToolAnnotations(readOnlyHint=True),
+    "admin_index_settings_set": ToolAnnotations(
+        destructiveHint=False, idempotentHint=True
+    ),
 }
 
 
-def get_tools(read_only_mode: bool = True) -> list[Callable]:
+def get_tools(
+    read_only_mode: bool = True,
+    admin_write_mode: bool = False,
+) -> list[Callable]:
     """Get the list of tools based on the mode settings.
 
-    This function determines which tools should be loaded based on the
-    READ_ONLY_MODE setting. When read_only_mode is True, write tools are excluded.
+    - READ_ONLY_TOOLS are always loaded.
+    - KV_WRITE_TOOLS load when read_only_mode is False.
+    - ADMIN_WRITE_TOOLS load only when read_only_mode is False AND
+      admin_write_mode is True. Cluster-structure mutation (index DDL) and
+      cluster-wide index settings are a higher privilege than data writes, so
+      disabling read-only alone does not expose them; an operator must also
+      opt in to admin writes.
     """
     tools = list(READ_ONLY_TOOLS)
 
     if not read_only_mode:
         # KV write tools are only loaded when READ_ONLY_MODE is False
         tools.extend(KV_WRITE_TOOLS)
+        if admin_write_mode:
+            tools.extend(ADMIN_WRITE_TOOLS)
 
     return tools
 
@@ -157,6 +198,11 @@ __all__ = [
     "explain_sql_plus_plus_query",
     "get_index_advisor_recommendations",
     "list_indexes",
+    "create_index",
+    "drop_index",
+    "build_deferred_indexes",
+    "admin_index_settings_get",
+    "admin_index_settings_set",
     "get_cluster_health_and_services",
     "get_queries_not_selective",
     "get_queries_not_using_covering_index",
@@ -168,6 +214,7 @@ __all__ = [
     # Tool categories
     "READ_ONLY_TOOLS",
     "KV_WRITE_TOOLS",
+    "ADMIN_WRITE_TOOLS",
     # Tool annotations
     "TOOL_ANNOTATIONS",
     # Convenience

--- a/src/cb_mcp/tools/bucket_admin.py
+++ b/src/cb_mcp/tools/bucket_admin.py
@@ -1,0 +1,458 @@
+"""
+Tools for bucket management.
+
+These tools create, update, delete, flush, compact, and load-sample buckets
+via the Couchbase Cluster Manager Management REST API
+(``/pools/default/buckets`` and ``/sampleBuckets/install``). They complement
+the read-only bucket-discovery tools ``get_buckets_in_cluster``,
+``get_scopes_in_bucket``, and ``get_scopes_and_collections_in_bucket``.
+
+Write gating
+------------
+Bucket lifecycle mutates cluster structure. These tools are loaded only when
+the server is *not* in read-only mode AND admin-write mode is enabled (see
+``tools/__init__.py`` ``get_tools`` and ``ADMIN_WRITE_TOOLS``). When an
+OAuth token is present, the caller must additionally hold the write scope;
+this mirrors the scope enforcement in ``run_sql_plus_plus_query`` so a
+read-scoped token cannot mutate buckets even when admin-write mode is on.
+
+REST vs. SDK
+------------
+Bucket lifecycle goes through the Cluster Manager REST endpoints, not the
+Couchbase SDK's Bucket Manager, so behavior stays consistent with the
+existing REST path used by ``list_indexes`` and ``admin_index_settings_*``
+(host extraction, TLS handling, and Capella root CA are all reused from
+``utils.index_utils``).
+
+Delete confirmation
+-------------------
+``delete_bucket`` requires both ``confirm=True`` AND a ``confirm_name`` that
+matches the target bucket name. This mirrors the Couchbase Web Console
+"type the bucket name to delete" pattern and is a UX guard against
+fat-finger destruction; combined with admin-write-mode gating and the
+write-scope check, three independent gates precede a bucket delete.
+
+License: MIT - Copyright (c) 2026 Chris Ahrendt
+"""
+
+import logging
+from typing import Any
+
+from fastmcp import Context
+from fastmcp.server.dependencies import get_access_token
+
+from ..utils.bucket_admin_rest import (
+    ALLOWED_COMPACT_ACTIONS,
+    ALLOWED_SAMPLE_BUCKETS,
+    assert_bucket_name,
+    compact_bucket_rest,
+    create_bucket_rest,
+    delete_bucket_rest,
+    flush_bucket_rest,
+    load_sample_bucket_rest,
+    update_bucket_rest,
+    validate_extra_bucket_keys,
+)
+from ..utils.config import get_settings
+from ..utils.constants import MCP_SERVER_NAME, SCOPE_WRITE
+
+logger = logging.getLogger(f"{MCP_SERVER_NAME}.tools.bucket_admin")
+
+
+def _require_write_scope() -> None:
+    """Raise ``PermissionError`` if a token is present but lacks the write scope.
+
+    No-op when no token is in context (stdio transport or OAuth disabled),
+    matching the behavior of ``run_sql_plus_plus_query`` so the same tool
+    body serves authenticated HTTP and unauthenticated stdio without
+    branching at registration time.
+    """
+    token = get_access_token()
+    if token is not None and SCOPE_WRITE not in (token.scopes or []):
+        held = sorted(set(token.scopes or []))
+        msg = (
+            f"Bucket admin requires the '{SCOPE_WRITE}' scope; token scopes are {held}."
+        )
+        logger.warning(msg)
+        raise PermissionError(msg)
+
+
+# --------------------------------------------------------------------------
+# Bucket parameter mapping (POST /pools/default/buckets accepts snake_case
+# for some keys and camelCase for others; we normalize to the endpoint's
+# actual key names)
+# --------------------------------------------------------------------------
+
+# Named bucket parameters exposed as tool arguments. Maps tool argument name
+# to the REST endpoint's form key. Verified against Couchbase Server docs
+# (rest-api/rest-bucket-create, rest-bucket-update) 2026-07-06.
+_BUCKET_PARAM_KEYS: dict[str, str] = {
+    "ram_quota_mb": "ramQuota",
+    "bucket_type": "bucketType",  # membase (couchbase) | ephemeral | memcached
+    "storage_backend": "storageBackend",  # couchstore | magma
+    "replica_number": "replicaNumber",
+    "replica_index": "replicaIndex",
+    "eviction_policy": "evictionPolicy",  # valueOnly | fullEviction | noEviction | nruEviction
+    "flush_enabled": "flushEnabled",  # 0 | 1 in the REST form
+    "max_ttl": "maxTTL",
+    "compression_mode": "compressionMode",  # off | passive | active
+    "conflict_resolution_type": "conflictResolutionType",  # seqno | lww | custom
+    "durability_min_level": "durabilityMinLevel",  # none | majority | majorityAndPersistActive | persistToMajority
+    "num_vbuckets": "numVBuckets",
+    "history_retention_seconds": "historyRetentionSeconds",
+    "history_retention_bytes": "historyRetentionBytes",
+    "history_retention_collection_default": "historyRetentionCollectionDefault",
+    "autocompaction_defined": "autoCompactionDefined",
+}
+
+# Allow-list of accepted camelCase form keys for the ``extra`` escape hatch.
+# The named parameters cover the documented parameter set; ``extra`` exists
+# for forward-compatibility. Any key not in this set is rejected before it
+# reaches the REST endpoint. When Couchbase documents a new bucket setting,
+# add its camelCase key here (and, ideally, a named parameter above).
+_VALID_BUCKET_FORM_KEYS: frozenset[str] = frozenset(_BUCKET_PARAM_KEYS.values())
+
+
+def _collect_bucket_params(
+    named: dict[str, Any], extra: dict[str, Any] | None
+) -> dict[str, Any]:
+    """Merge named args and validated extras into a REST form dict."""
+    params: dict[str, Any] = {
+        _BUCKET_PARAM_KEYS[k]: v for k, v in named.items() if v is not None
+    }
+    if extra:
+        validate_extra_bucket_keys(extra, _VALID_BUCKET_FORM_KEYS)
+        params.update(extra)
+    return params
+
+
+# --------------------------------------------------------------------------
+# Tool functions
+# --------------------------------------------------------------------------
+
+
+def create_bucket(
+    ctx: Context,
+    bucket_name: str | None = None,
+    body: dict[str, Any] | None = None,
+    ram_quota_mb: int | None = None,
+    bucket_type: str | None = None,
+    storage_backend: str | None = None,
+    replica_number: int | None = None,
+    replica_index: int | None = None,
+    eviction_policy: str | None = None,
+    flush_enabled: bool | None = None,
+    max_ttl: int | None = None,
+    compression_mode: str | None = None,
+    conflict_resolution_type: str | None = None,
+    durability_min_level: str | None = None,
+    num_vbuckets: int | None = None,
+    history_retention_seconds: int | None = None,
+    history_retention_bytes: int | None = None,
+    history_retention_collection_default: bool | None = None,
+    autocompaction_defined: bool | None = None,
+    extra: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Create a bucket on the cluster.
+
+    Two ways to call this:
+
+    - Raw ``body``: pass a dict of Couchbase REST form keys (camelCase).
+      Every key is validated against the documented bucket-parameter
+      allow-list; unknown keys are rejected. ``body["name"]`` must be
+      present and match ``bucket_name`` if both are provided.
+    - Structured fields: pass ``bucket_name`` (required) and ``ram_quota_mb``
+      (required), plus any subset of the optional named parameters (or
+      ``extra`` for forward-compatibility settings). Only supplied values
+      are sent, matching the endpoint's leave-unspecified-alone semantics
+      on update but combined with server defaults on create.
+
+    Returns a dict with the executed body and the cluster's response.
+    """
+    _require_write_scope()
+
+    if body is not None:
+        if bucket_name and body.get("name") and body["name"] != bucket_name:
+            raise ValueError(
+                f"bucket_name={bucket_name!r} does not match body['name']={body['name']!r}"
+            )
+        name = body.get("name") or bucket_name
+        if not name:
+            raise ValueError("body must include a 'name' key or provide bucket_name")
+        assert_bucket_name(name)
+        # Validate ALL body keys, since we're accepting a raw form
+        validate_extra_bucket_keys(
+            {k: v for k, v in body.items() if k != "name"},
+            _VALID_BUCKET_FORM_KEYS,
+        )
+        form = dict(body)
+        form["name"] = name
+    else:
+        if not bucket_name:
+            raise ValueError("bucket_name is required when body is not provided")
+        assert_bucket_name(bucket_name)
+        if ram_quota_mb is None:
+            raise ValueError(
+                "ram_quota_mb is required when body is not provided (Couchbase "
+                "requires an explicit RAM quota for new buckets)"
+            )
+        named = {
+            "ram_quota_mb": ram_quota_mb,
+            "bucket_type": bucket_type,
+            "storage_backend": storage_backend,
+            "replica_number": replica_number,
+            "replica_index": replica_index,
+            "eviction_policy": eviction_policy,
+            "flush_enabled": flush_enabled,
+            "max_ttl": max_ttl,
+            "compression_mode": compression_mode,
+            "conflict_resolution_type": conflict_resolution_type,
+            "durability_min_level": durability_min_level,
+            "num_vbuckets": num_vbuckets,
+            "history_retention_seconds": history_retention_seconds,
+            "history_retention_bytes": history_retention_bytes,
+            "history_retention_collection_default": history_retention_collection_default,
+            "autocompaction_defined": autocompaction_defined,
+        }
+        form = {"name": bucket_name}
+        form.update(_collect_bucket_params(named, extra))
+
+    logger.info(f"Creating bucket {form['name']!r}")
+    settings = get_settings(ctx)
+    result = create_bucket_rest(
+        connection_string=settings["connection_string"],
+        username=settings["username"],
+        password=settings["password"],
+        form=form,
+        ca_cert_path=settings.get("ca_cert_path"),
+    )
+    return {"body": form, "result": result}
+
+
+def update_bucket(
+    ctx: Context,
+    bucket_name: str,
+    body: dict[str, Any] | None = None,
+    ram_quota_mb: int | None = None,
+    replica_number: int | None = None,
+    replica_index: int | None = None,
+    eviction_policy: str | None = None,
+    flush_enabled: bool | None = None,
+    max_ttl: int | None = None,
+    compression_mode: str | None = None,
+    durability_min_level: str | None = None,
+    history_retention_seconds: int | None = None,
+    history_retention_bytes: int | None = None,
+    history_retention_collection_default: bool | None = None,
+    autocompaction_defined: bool | None = None,
+    extra: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Update an existing bucket's settings.
+
+    Two ways to call this:
+
+    - Raw ``body``: dict of Couchbase REST form keys (camelCase). Validated
+      against the same allow-list ``create_bucket`` uses.
+    - Structured fields: pass any subset of the optional named parameters
+      (or ``extra`` for forward-compatibility). Only supplied values are
+      sent; unspecified settings are left unchanged by the server.
+
+    Note: ``bucket_type``, ``storage_backend``, ``conflict_resolution_type``,
+    and ``num_vbuckets`` are set at create time and cannot be updated; they
+    are intentionally omitted from the named parameters here. Attempting to
+    change them via ``body`` or ``extra`` will produce a server-side error.
+
+    Returns a dict with the executed body and the cluster's response.
+    """
+    _require_write_scope()
+    assert_bucket_name(bucket_name)
+
+    if body is not None:
+        validate_extra_bucket_keys(body, _VALID_BUCKET_FORM_KEYS)
+        form = dict(body)
+    else:
+        named = {
+            "ram_quota_mb": ram_quota_mb,
+            "replica_number": replica_number,
+            "replica_index": replica_index,
+            "eviction_policy": eviction_policy,
+            "flush_enabled": flush_enabled,
+            "max_ttl": max_ttl,
+            "compression_mode": compression_mode,
+            "durability_min_level": durability_min_level,
+            "history_retention_seconds": history_retention_seconds,
+            "history_retention_bytes": history_retention_bytes,
+            "history_retention_collection_default": history_retention_collection_default,
+            "autocompaction_defined": autocompaction_defined,
+        }
+        form = _collect_bucket_params(named, extra)
+
+    if not form:
+        raise ValueError(
+            "Provide at least one field to update (a named parameter, "
+            "'body', or an 'extra' entry)."
+        )
+
+    logger.info(f"Updating bucket {bucket_name!r}")
+    settings = get_settings(ctx)
+    result = update_bucket_rest(
+        connection_string=settings["connection_string"],
+        username=settings["username"],
+        password=settings["password"],
+        bucket_name=bucket_name,
+        form=form,
+        ca_cert_path=settings.get("ca_cert_path"),
+    )
+    return {"bucket": bucket_name, "body": form, "result": result}
+
+
+def delete_bucket(
+    ctx: Context,
+    bucket_name: str,
+    confirm: bool = False,
+    confirm_name: str | None = None,
+) -> dict[str, Any]:
+    """Delete a bucket. Irreversible; deletes all data in the bucket.
+
+    Requires BOTH:
+
+    - ``confirm=True``
+    - ``confirm_name`` set to the exact bucket name
+
+    The name-match is a UX guard against fat-finger deletes, matching the
+    Couchbase Web Console pattern. Combined with the admin-write-mode gate
+    and the OAuth write-scope check (when applicable), three independent
+    gates precede a delete.
+
+    Returns a dict with the deleted bucket name and the cluster response.
+    """
+    _require_write_scope()
+    assert_bucket_name(bucket_name)
+
+    if not confirm:
+        raise ValueError(
+            "delete_bucket requires confirm=True. This operation is "
+            "irreversible and deletes all data in the bucket."
+        )
+    if confirm_name != bucket_name:
+        raise ValueError(
+            "delete_bucket requires confirm_name to exactly match "
+            f"bucket_name ({bucket_name!r}). This guard against fat-finger "
+            "deletion matches the Couchbase Web Console pattern."
+        )
+
+    logger.warning(f"Deleting bucket {bucket_name!r}")
+    settings = get_settings(ctx)
+    result = delete_bucket_rest(
+        connection_string=settings["connection_string"],
+        username=settings["username"],
+        password=settings["password"],
+        bucket_name=bucket_name,
+        ca_cert_path=settings.get("ca_cert_path"),
+    )
+    return {"bucket": bucket_name, "deleted": True, "result": result}
+
+
+def flush_bucket(
+    ctx: Context,
+    bucket_name: str,
+    confirm: bool = False,
+) -> dict[str, Any]:
+    """Flush a bucket, deleting all documents but keeping the bucket itself.
+
+    The bucket must have been created with ``flush_enabled=True`` (via
+    ``create_bucket``) or updated to allow flush before this call succeeds;
+    Couchbase returns 400 otherwise.
+
+    Requires ``confirm=True``. Combined with the admin-write-mode gate and
+    the write-scope check, three independent gates precede a flush.
+
+    Returns a dict with the flushed bucket name and the cluster response.
+    """
+    _require_write_scope()
+    assert_bucket_name(bucket_name)
+
+    if not confirm:
+        raise ValueError(
+            "flush_bucket requires confirm=True. This operation deletes "
+            "every document in the bucket."
+        )
+
+    logger.warning(f"Flushing bucket {bucket_name!r}")
+    settings = get_settings(ctx)
+    result = flush_bucket_rest(
+        connection_string=settings["connection_string"],
+        username=settings["username"],
+        password=settings["password"],
+        bucket_name=bucket_name,
+        ca_cert_path=settings.get("ca_cert_path"),
+    )
+    return {"bucket": bucket_name, "flushed": True, "result": result}
+
+
+def compact_bucket(
+    ctx: Context,
+    bucket_name: str,
+    action: str = "start",
+) -> dict[str, Any]:
+    """Start or cancel a bucket compaction task.
+
+    ``action`` is either ``"start"`` (POST ``.../controller/compactBucket``)
+    or ``"cancel"`` (POST ``.../controller/cancelBucketCompaction``). Not
+    destructive of data; compaction reclaims disk space. Cancel is idempotent
+    if no task is running.
+
+    Returns a dict with the bucket, action, and the cluster response.
+    """
+    _require_write_scope()
+    assert_bucket_name(bucket_name)
+
+    if action not in ALLOWED_COMPACT_ACTIONS:
+        raise ValueError(
+            f"action must be one of {sorted(ALLOWED_COMPACT_ACTIONS)}, got {action!r}"
+        )
+
+    logger.info(f"Compact ({action}) bucket {bucket_name!r}")
+    settings = get_settings(ctx)
+    result = compact_bucket_rest(
+        connection_string=settings["connection_string"],
+        username=settings["username"],
+        password=settings["password"],
+        bucket_name=bucket_name,
+        action=action,
+        ca_cert_path=settings.get("ca_cert_path"),
+    )
+    return {"bucket": bucket_name, "action": action, "result": result}
+
+
+def load_sample_bucket(
+    ctx: Context,
+    sample_name: str,
+) -> dict[str, Any]:
+    """Install one of Couchbase's built-in sample datasets.
+
+    ``sample_name`` must be one of the documented sample bucket names
+    (``travel-sample``, ``beer-sample``, ``gamesim-sample``). Any other
+    value is rejected. Installation is asynchronous on the server side;
+    the initial response indicates the task was accepted.
+
+    Returns a dict with the sample name and the cluster response.
+    """
+    _require_write_scope()
+
+    if sample_name not in ALLOWED_SAMPLE_BUCKETS:
+        raise ValueError(
+            f"sample_name must be one of {sorted(ALLOWED_SAMPLE_BUCKETS)}, "
+            f"got {sample_name!r}"
+        )
+
+    logger.info(f"Loading sample bucket {sample_name!r}")
+    settings = get_settings(ctx)
+    result = load_sample_bucket_rest(
+        connection_string=settings["connection_string"],
+        username=settings["username"],
+        password=settings["password"],
+        sample_name=sample_name,
+        ca_cert_path=settings.get("ca_cert_path"),
+    )
+    return {"sample": sample_name, "result": result}

--- a/src/cb_mcp/tools/index_admin.py
+++ b/src/cb_mcp/tools/index_admin.py
@@ -1,0 +1,328 @@
+"""
+Tools for index management (DDL).
+
+These tools create, drop, and build GSI indexes and read/update Index
+Service settings. They complement the read-only ``index.py`` tools
+(``list_indexes`` and ``get_index_advisor_recommendations``): the advisor
+recommends indexes, ``list_indexes`` shows them, and these tools act on
+them.
+
+Write gating
+------------
+Index DDL mutates cluster structure. These tools are loaded only when the
+server is *not* in read-only mode AND admin-write mode is enabled (see
+``tools/__init__.py`` ``get_tools`` and ``ADMIN_WRITE_TOOLS``). When an
+OAuth token is present, the caller must additionally hold the write scope;
+this mirrors the scope enforcement in ``run_sql_plus_plus_query`` so a
+read-scoped token cannot mutate indexes even when admin-write mode is on.
+
+DDL is executed through ``run_cluster_query`` rather than
+``run_sql_plus_plus_query``. The latter classifies ``CREATE``/``DROP``/
+``BUILD INDEX`` as structure modifications and blocks them under read-only
+mode; routing DDL through the cluster path keeps load-time gating
+(``ADMIN_WRITE_TOOLS`` + admin-write mode + scope) as the single, explicit
+enforcement point instead of double-gating.
+
+License: MIT - Copyright (c) 2026 Chris Ahrendt
+"""
+
+import logging
+from typing import Any
+
+from fastmcp import Context
+from fastmcp.server.dependencies import get_access_token
+
+from ..utils.config import get_settings
+from ..utils.constants import MCP_SERVER_NAME, SCOPE_WRITE
+from ..utils.index_ddl import (
+    assert_index_create_ddl,
+    assert_index_drop_ddl,
+    safe_ident,
+)
+from ..utils.index_settings import get_gsi_settings, set_gsi_settings
+from .query import run_cluster_query
+
+logger = logging.getLogger(f"{MCP_SERVER_NAME}.tools.index_admin")
+
+
+def _require_write_scope() -> None:
+    """Raise ``PermissionError`` if a token is present but lacks the write scope.
+
+    No-op when no token is in context (stdio transport or OAuth disabled),
+    matching the behavior of ``run_sql_plus_plus_query`` so the same tool
+    body serves authenticated HTTP and unauthenticated stdio without
+    branching at registration time.
+    """
+    token = get_access_token()
+    if token is not None and SCOPE_WRITE not in (token.scopes or []):
+        held = sorted(set(token.scopes or []))
+        msg = f"Index DDL requires the '{SCOPE_WRITE}' scope; token scopes are {held}."
+        logger.warning(msg)
+        raise PermissionError(msg)
+
+
+def create_index(
+    ctx: Context,
+    statement: str | None = None,
+    index_name: str | None = None,
+    bucket_name: str | None = None,
+    scope_name: str | None = None,
+    collection_name: str | None = None,
+    fields: list[str] | None = None,
+    is_primary: bool = False,
+    num_replica: int | None = None,
+    defer_build: bool = False,
+) -> dict[str, Any]:
+    """Create a GSI index.
+
+    Two ways to call this:
+
+    - Raw ``statement``: pass a full SQL++ index-create statement. Only
+      CREATE INDEX / CREATE PRIMARY INDEX / BUILD INDEX / CREATE
+      [HYPERSCALE|COMPOSITE] VECTOR INDEX are accepted; any other SQL++ is
+      rejected.
+    - Structured fields: provide ``bucket_name`` (and optionally
+      ``scope_name`` / ``collection_name``, defaulting to ``_default``) with
+      either ``is_primary=True`` or an ``index_name`` plus ``fields``.
+      Optional ``num_replica`` and ``defer_build`` become a WITH clause.
+
+    Returns a dict with the executed statement and result rows.
+    """
+    _require_write_scope()
+
+    if statement:
+        invalid = assert_index_create_ddl(statement)
+        if invalid:
+            raise ValueError(invalid)
+        stmt = statement
+    else:
+        if not bucket_name:
+            raise ValueError("bucket_name is required when statement is not provided")
+        bucket = safe_ident(bucket_name)
+        scope = safe_ident(scope_name or "_default")
+        coll = safe_ident(collection_name or "_default")
+
+        if is_primary:
+            idx = safe_ident(index_name) if index_name else ""
+            target = f"{idx} " if idx else ""
+            stmt = f"CREATE PRIMARY INDEX {target}ON {bucket}.{scope}.{coll}"
+        else:
+            if not index_name:
+                raise ValueError("index_name is required for non-primary indexes")
+            if not fields:
+                raise ValueError("fields are required for non-primary indexes")
+            idx = safe_ident(index_name)
+            field_list = ", ".join(safe_ident(f) for f in fields)
+            stmt = f"CREATE INDEX {idx} ON {bucket}.{scope}.{coll} ({field_list})"
+
+        withs = []
+        if num_replica is not None:
+            withs.append(f'"num_replica": {int(num_replica)}')
+        if defer_build:
+            withs.append('"defer_build": true')
+        if withs:
+            stmt += " WITH {" + ", ".join(withs) + "}"
+
+    logger.info("Executing index create")
+    rows = run_cluster_query(ctx, stmt)
+    return {"statement": stmt, "results": rows}
+
+
+def drop_index(
+    ctx: Context,
+    statement: str | None = None,
+    index_name: str | None = None,
+    bucket_name: str | None = None,
+    scope_name: str | None = None,
+    collection_name: str | None = None,
+    is_primary: bool = False,
+) -> dict[str, Any]:
+    """Drop a GSI index.
+
+    Two ways to call this:
+
+    - Raw ``statement``: a full DROP INDEX / DROP PRIMARY INDEX / DROP VECTOR
+      INDEX statement. Any other SQL++ is rejected.
+    - Structured fields: ``bucket_name`` (and optional ``scope_name`` /
+      ``collection_name``) with either ``is_primary=True`` or ``index_name``.
+
+    Returns a dict with the executed statement and result rows.
+    """
+    _require_write_scope()
+
+    if statement:
+        invalid = assert_index_drop_ddl(statement)
+        if invalid:
+            raise ValueError(invalid)
+        stmt = statement
+    else:
+        if not bucket_name:
+            raise ValueError("bucket_name is required when statement is not provided")
+        bucket = safe_ident(bucket_name)
+        scope = safe_ident(scope_name or "_default")
+        coll = safe_ident(collection_name or "_default")
+
+        if is_primary:
+            stmt = f"DROP PRIMARY INDEX ON {bucket}.{scope}.{coll}"
+        else:
+            if not index_name:
+                raise ValueError("index_name is required for non-primary drop")
+            idx = safe_ident(index_name)
+            stmt = f"DROP INDEX {idx} ON {bucket}.{scope}.{coll}"
+
+    logger.info("Executing index drop")
+    rows = run_cluster_query(ctx, stmt)
+    return {"statement": stmt, "results": rows}
+
+
+def build_deferred_indexes(
+    ctx: Context,
+    bucket_name: str,
+    index_names: list[str],
+    scope_name: str | None = None,
+    collection_name: str | None = None,
+) -> dict[str, Any]:
+    """Build one or more deferred GSI indexes.
+
+    ``bucket_name`` and ``index_names`` are required. Provide both
+    ``scope_name`` and ``collection_name`` to build within a specific
+    collection (Couchbase 7+); omit both for a bucket-level build.
+
+    Returns a dict with the executed statement and result rows.
+    """
+    _require_write_scope()
+
+    if not index_names:
+        raise ValueError("index_names must contain at least one index name")
+
+    bucket = safe_ident(bucket_name)
+    if scope_name and collection_name:
+        keyspace = f"{bucket}.{safe_ident(scope_name)}.{safe_ident(collection_name)}"
+    elif scope_name or collection_name:
+        raise ValueError("scope_name and collection_name must be provided together")
+    else:
+        keyspace = bucket
+
+    names = ", ".join(safe_ident(n) for n in index_names)
+    stmt = f"BUILD INDEX ON {keyspace} ({names})"
+
+    logger.info("Executing deferred index build")
+    rows = run_cluster_query(ctx, stmt)
+    return {"statement": stmt, "results": rows}
+
+
+# --------------------------------------------------------------------------
+# GSI settings (cluster-manager /settings/indexes, port 8091/18091)
+# --------------------------------------------------------------------------
+
+# Named GSI settings exposed as explicit tool parameters. Maps the tool's
+# snake_case argument to the endpoint's camelCase form key. These are the
+# complete set of keys documented for POST /settings/indexes (Couchbase Server
+# 8.0). Verified against docs 2026-07-02.
+_GSI_SETTING_KEYS: dict[str, str] = {
+    "indexer_threads": "indexerThreads",
+    "log_level": "logLevel",
+    "max_rollback_points": "maxRollbackPoints",
+    "storage_mode": "storageMode",
+    "num_replica": "numReplica",
+    "redistribute_indexes": "redistributeIndexes",
+    "enable_page_bloom_filter": "enablePageBloomFilter",
+    "enable_shard_affinity": "enableShardAffinity",
+    "memory_snapshot_interval": "memorySnapshotInterval",
+    "stable_snapshot_interval": "stableSnapshotInterval",
+}
+
+# Allow-list of accepted camelCase form keys for the ``extra`` escape hatch.
+# The named parameters already cover the full documented key set; ``extra``
+# exists for forward-compatibility if a future server version adds a key. It
+# is validated against this allow-list so it cannot be used to POST arbitrary
+# keys to /settings/indexes. When Couchbase documents a new GSI setting, add
+# its camelCase key here (and, ideally, a named parameter above).
+_VALID_GSI_FORM_KEYS: frozenset[str] = frozenset(_GSI_SETTING_KEYS.values())
+
+
+def admin_index_settings_get(ctx: Context) -> dict[str, Any]:
+    """Get the cluster's Global Secondary Index (GSI) settings.
+
+    Reads the GSI settings from the cluster manager (/settings/indexes).
+    Returns the settings as a dict, e.g. indexerThreads, logLevel,
+    maxRollbackPoints, storageMode, numReplica, redistributeIndexes.
+    Read-only.
+    """
+    settings = get_settings(ctx)
+    return get_gsi_settings(
+        connection_string=settings["connection_string"],
+        username=settings["username"],
+        password=settings["password"],
+        ca_cert_path=settings.get("ca_cert_path"),
+    )
+
+
+def admin_index_settings_set(
+    ctx: Context,
+    indexer_threads: int | None = None,
+    log_level: str | None = None,
+    max_rollback_points: int | None = None,
+    storage_mode: str | None = None,
+    num_replica: int | None = None,
+    redistribute_indexes: bool | None = None,
+    enable_page_bloom_filter: bool | None = None,
+    enable_shard_affinity: bool | None = None,
+    memory_snapshot_interval: int | None = None,
+    stable_snapshot_interval: int | None = None,
+    extra: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Update the cluster's Global Secondary Index (GSI) settings.
+
+    Provide any subset of the named parameters; only supplied values are
+    sent, and unspecified settings are left unchanged by the server. Use
+    ``extra`` to pass settings not covered by the named parameters (keys must
+    be documented GSI setting camelCase names; unknown keys are rejected).
+    Returns the resulting settings after the update.
+
+    Note: Couchbase advises changing most GSI settings only when directed by
+    Couchbase Support. This tool loads only when read-only mode is off and
+    admin-write mode is on, and (when OAuth is active) requires the write
+    scope.
+    """
+    _require_write_scope()
+
+    named = {
+        "indexer_threads": indexer_threads,
+        "log_level": log_level,
+        "max_rollback_points": max_rollback_points,
+        "storage_mode": storage_mode,
+        "num_replica": num_replica,
+        "redistribute_indexes": redistribute_indexes,
+        "enable_page_bloom_filter": enable_page_bloom_filter,
+        "enable_shard_affinity": enable_shard_affinity,
+        "memory_snapshot_interval": memory_snapshot_interval,
+        "stable_snapshot_interval": stable_snapshot_interval,
+    }
+    params: dict[str, Any] = {
+        _GSI_SETTING_KEYS[k]: v for k, v in named.items() if v is not None
+    }
+    if extra:
+        unknown = sorted(set(extra) - _VALID_GSI_FORM_KEYS)
+        if unknown:
+            raise ValueError(
+                f"Unknown GSI setting key(s) in 'extra': {unknown}. Allowed "
+                f"keys are {sorted(_VALID_GSI_FORM_KEYS)}. Use a named "
+                "parameter where one exists."
+            )
+        params.update(extra)
+
+    if not params:
+        raise ValueError(
+            "Provide at least one setting to update (a named parameter or "
+            "an 'extra' entry)."
+        )
+
+    settings = get_settings(ctx)
+    return set_gsi_settings(
+        connection_string=settings["connection_string"],
+        username=settings["username"],
+        password=settings["password"],
+        params=params,
+        ca_cert_path=settings.get("ca_cert_path"),
+    )

--- a/src/cb_mcp/utils/bucket_admin_rest.py
+++ b/src/cb_mcp/utils/bucket_admin_rest.py
@@ -1,0 +1,368 @@
+"""
+REST client for the Cluster Manager bucket-lifecycle endpoints.
+
+Bucket lifecycle is served by the cluster manager on port 8091 (18091 for
+TLS) at ``/pools/default/buckets`` (create/list/update/delete),
+``/pools/default/buckets/{name}/controller/doFlush`` (flush),
+``/pools/default/buckets/{name}/controller/compactBucket`` and
+``.../cancelBucketCompaction`` (compact),  and ``/sampleBuckets/install``
+(sample-data loader).
+
+Verified against Couchbase Server docs (rest-api/rest-bucket-create,
+rest-bucket-update, rest-bucket-delete, rest-bucket-flush,
+rest-bucket-compaction, rest-sample-buckets) 2026-07-06.
+
+This helper reuses the connection-string host extraction and SSL
+verification logic already present in ``index_utils`` so behavior (Capella
+root CA handling, multi-host fallback, TLS detection) stays consistent with
+the existing index REST path.
+
+License: MIT - Copyright (c) 2026 Chris Ahrendt
+"""
+
+import json
+import logging
+import re
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from .constants import MCP_SERVER_NAME
+from .index_utils import (
+    _determine_ssl_verification,
+    _extract_hosts_from_connection_string,
+)
+
+logger = logging.getLogger(f"{MCP_SERVER_NAME}.utils.bucket_admin_rest")
+
+# Cluster-manager ports for bucket lifecycle (same as GSI settings).
+_MGMT_PORT = 8091
+_MGMT_TLS_PORT = 18091
+
+_BUCKETS_PATH = "/pools/default/buckets"
+_SAMPLE_BUCKETS_PATH = "/sampleBuckets/install"
+
+# Bucket name character class per Couchbase docs: letters, digits, and
+# ``.``, ``-``, ``_``, ``%``. Length 1-100 chars. Reject anything else
+# BEFORE it enters a URL path to avoid any injection surface.
+_BUCKET_NAME_RE = re.compile(r"^[A-Za-z0-9._\-%]{1,100}$")
+
+# Documented sample buckets in Couchbase Server 7.x/8.x. New samples added
+# by future server versions should be added here explicitly.
+ALLOWED_SAMPLE_BUCKETS: frozenset[str] = frozenset(
+    {"travel-sample", "beer-sample", "gamesim-sample"}
+)
+
+# Compaction verbs. Kept as a small allow-list rather than accepting any
+# string so a caller can't smuggle an arbitrary controller path.
+ALLOWED_COMPACT_ACTIONS: frozenset[str] = frozenset({"start", "cancel"})
+
+
+# --------------------------------------------------------------------------
+# Validators (imported by bucket_admin.py; keeping them near the REST layer
+# so the allow-lists and the encoding stay coupled)
+# --------------------------------------------------------------------------
+
+
+def assert_bucket_name(name: str) -> None:
+    """Reject bucket names that don't match Couchbase's documented charset.
+
+    Also prevents path traversal / injection via bucket_name since the value
+    is interpolated into a REST URL path.
+    """
+    if not isinstance(name, str) or not _BUCKET_NAME_RE.fullmatch(name):
+        raise ValueError(
+            f"Invalid bucket name {name!r}. Bucket names must be 1-100 chars "
+            "of [A-Za-z0-9._%-]."
+        )
+
+
+def _encode_path_segment(value: str) -> str:
+    """URL-encode a value for use as a REST path segment.
+
+    Couchbase documents ``%`` as a valid bucket-name character. When a caller
+    provides a name like ``%2f%2e%2e`` (URL-encoded ``/../``), the raw
+    interpolation would send that literal to the server; some HTTP frameworks
+    decode-then-route, opening a path-confusion vector even though the caller
+    is already authenticated. Encoding the segment with ``safe=""`` produces
+    ``%252f%252e%252e``, which the server treats as an opaque bucket name.
+    """
+    return quote(value, safe="")
+
+
+def validate_extra_bucket_keys(extra: dict[str, Any], allowed: frozenset[str]) -> None:
+    """Reject any key in ``extra`` that is not in ``allowed``.
+
+    The named parameters cover the documented parameter set; ``extra``
+    exists for forward-compatibility. Any unknown key is rejected to
+    prevent posting arbitrary form fields to the bucket endpoint.
+    """
+    unknown = sorted(set(extra) - allowed)
+    if unknown:
+        raise ValueError(
+            f"Unknown bucket setting key(s) in 'extra' or 'body': {unknown}. "
+            f"Allowed keys are {sorted(allowed)}. Use a named parameter "
+            "where one exists."
+        )
+
+
+# --------------------------------------------------------------------------
+# Small internals shared by every REST call
+# --------------------------------------------------------------------------
+
+
+def _mgmt_base(connection_string: str) -> tuple[str, int]:
+    """Return (scheme, port) for the cluster-manager endpoint."""
+    is_tls = connection_string.lower().startswith("couchbases://")
+    return ("https", _MGMT_TLS_PORT) if is_tls else ("http", _MGMT_PORT)
+
+
+def _form_value(value: Any) -> str:
+    """Render a value for the form-urlencoded body.
+
+    Bucket endpoints are inconsistent — flushEnabled takes 0/1, most others
+    take true/false, ram-quota takes an int. We render:
+    - bool  -> "true"/"false" (endpoint accepts either 0/1 or true/false for flushEnabled)
+    - int   -> str(int)
+    - dict  -> json.dumps (for autoCompactionSettings, etc.)
+    - other -> str()
+    """
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, int | float):
+        return str(value)
+    if isinstance(value, dict):
+        return json.dumps(value)
+    return str(value)
+
+
+def _request(
+    *,
+    method: str,
+    connection_string: str,
+    username: str,
+    password: str,
+    ca_cert_path: str | None,
+    timeout: int,
+    path: str,
+    data: dict[str, str] | None = None,
+    expected_ok: tuple[int, ...] = (200, 202),
+) -> dict[str, Any]:
+    """Issue a REST request to the cluster manager, trying each host in turn.
+
+    On success returns the parsed JSON body when present, or an empty dict
+    (many bucket endpoints return an empty body on 202 Accepted). Raises
+    ``RuntimeError`` if every host fails.
+    """
+    hosts = _extract_hosts_from_connection_string(connection_string)
+    scheme, port = _mgmt_base(connection_string)
+    verify_ssl = _determine_ssl_verification(connection_string, ca_cert_path)
+
+    last_error: Exception | None = None
+    with httpx.Client(verify=verify_ssl, timeout=timeout) as client:
+        for host in hosts:
+            url = f"{scheme}://{host}:{port}{path}"
+            try:
+                logger.info(f"{method} {url}")
+                if method == "GET":
+                    resp = client.get(url, auth=(username, password))
+                elif method == "DELETE":
+                    resp = client.delete(url, auth=(username, password))
+                elif method == "POST":
+                    resp = client.post(url, data=data, auth=(username, password))
+                else:
+                    raise ValueError(f"unsupported HTTP method: {method}")
+                if resp.status_code not in expected_ok:
+                    resp.raise_for_status()
+                content_type = resp.headers.get("content-type", "")
+                if resp.content and content_type.startswith("application/json"):
+                    return resp.json()
+                return {}
+            except httpx.HTTPError as e:
+                logger.warning(f"Bucket-admin {method} failed on {host}: {e}")
+                last_error = e
+
+    error_msg = f"Bucket-admin {method} {path} failed on all hosts: {hosts}"
+    if last_error:
+        error_msg += f". Last error: {last_error}"
+    logger.error(error_msg)
+    raise RuntimeError(error_msg)
+
+
+# --------------------------------------------------------------------------
+# Public functions used by tools/bucket_admin.py
+# --------------------------------------------------------------------------
+
+
+def create_bucket_rest(
+    connection_string: str,
+    username: str,
+    password: str,
+    form: dict[str, Any],
+    ca_cert_path: str | None = None,
+    timeout: int = 30,
+) -> dict[str, Any]:
+    """POST /pools/default/buckets to create a bucket."""
+    if "name" not in form:
+        raise ValueError("form must include 'name'")
+    body = {k: _form_value(v) for k, v in form.items() if v is not None}
+    return _request(
+        method="POST",
+        connection_string=connection_string,
+        username=username,
+        password=password,
+        ca_cert_path=ca_cert_path,
+        timeout=timeout,
+        path=_BUCKETS_PATH,
+        data=body,
+    )
+
+
+def update_bucket_rest(
+    connection_string: str,
+    username: str,
+    password: str,
+    bucket_name: str,
+    form: dict[str, Any],
+    ca_cert_path: str | None = None,
+    timeout: int = 30,
+) -> dict[str, Any]:
+    """POST /pools/default/buckets/{name} to update an existing bucket."""
+    assert_bucket_name(bucket_name)
+    if not form:
+        raise ValueError("form must contain at least one setting to update")
+    body = {k: _form_value(v) for k, v in form.items() if v is not None}
+    return _request(
+        method="POST",
+        connection_string=connection_string,
+        username=username,
+        password=password,
+        ca_cert_path=ca_cert_path,
+        timeout=timeout,
+        path=f"{_BUCKETS_PATH}/{_encode_path_segment(bucket_name)}",
+        data=body,
+    )
+
+
+def delete_bucket_rest(
+    connection_string: str,
+    username: str,
+    password: str,
+    bucket_name: str,
+    ca_cert_path: str | None = None,
+    timeout: int = 30,
+) -> dict[str, Any]:
+    """DELETE /pools/default/buckets/{name}."""
+    assert_bucket_name(bucket_name)
+    return _request(
+        method="DELETE",
+        connection_string=connection_string,
+        username=username,
+        password=password,
+        ca_cert_path=ca_cert_path,
+        timeout=timeout,
+        path=f"{_BUCKETS_PATH}/{_encode_path_segment(bucket_name)}",
+    )
+
+
+def flush_bucket_rest(
+    connection_string: str,
+    username: str,
+    password: str,
+    bucket_name: str,
+    ca_cert_path: str | None = None,
+    timeout: int = 30,
+) -> dict[str, Any]:
+    """POST /pools/default/buckets/{name}/controller/doFlush."""
+    assert_bucket_name(bucket_name)
+    return _request(
+        method="POST",
+        connection_string=connection_string,
+        username=username,
+        password=password,
+        ca_cert_path=ca_cert_path,
+        timeout=timeout,
+        path=f"{_BUCKETS_PATH}/{_encode_path_segment(bucket_name)}/controller/doFlush",
+    )
+
+
+def compact_bucket_rest(
+    connection_string: str,
+    username: str,
+    password: str,
+    bucket_name: str,
+    action: str,
+    ca_cert_path: str | None = None,
+    timeout: int = 30,
+) -> dict[str, Any]:
+    """POST /pools/default/buckets/{name}/controller/{compactBucket|cancelBucketCompaction}."""
+    assert_bucket_name(bucket_name)
+    if action not in ALLOWED_COMPACT_ACTIONS:
+        raise ValueError(
+            f"action must be one of {sorted(ALLOWED_COMPACT_ACTIONS)}, got {action!r}"
+        )
+    controller = "compactBucket" if action == "start" else "cancelBucketCompaction"
+    return _request(
+        method="POST",
+        connection_string=connection_string,
+        username=username,
+        password=password,
+        ca_cert_path=ca_cert_path,
+        timeout=timeout,
+        path=f"{_BUCKETS_PATH}/{_encode_path_segment(bucket_name)}/controller/{controller}",
+    )
+
+
+def load_sample_bucket_rest(
+    connection_string: str,
+    username: str,
+    password: str,
+    sample_name: str,
+    ca_cert_path: str | None = None,
+    timeout: int = 60,
+) -> dict[str, Any]:
+    """POST /sampleBuckets/install with the sample name.
+
+    Body is a JSON array of sample names, per Couchbase docs. Response is a
+    202 Accepted with an empty or task-list body; the sample loads
+    asynchronously.
+    """
+    if sample_name not in ALLOWED_SAMPLE_BUCKETS:
+        raise ValueError(
+            f"sample_name must be one of {sorted(ALLOWED_SAMPLE_BUCKETS)}, "
+            f"got {sample_name!r}"
+        )
+    hosts = _extract_hosts_from_connection_string(connection_string)
+    scheme, port = _mgmt_base(connection_string)
+    verify_ssl = _determine_ssl_verification(connection_string, ca_cert_path)
+    payload = json.dumps([sample_name])
+
+    last_error: Exception | None = None
+    with httpx.Client(verify=verify_ssl, timeout=timeout) as client:
+        for host in hosts:
+            url = f"{scheme}://{host}:{port}{_SAMPLE_BUCKETS_PATH}"
+            try:
+                logger.info(f"POST {url} (sample={sample_name})")
+                resp = client.post(
+                    url,
+                    content=payload,
+                    headers={"content-type": "application/json"},
+                    auth=(username, password),
+                )
+                if resp.status_code not in (200, 202):
+                    resp.raise_for_status()
+                if resp.content and resp.headers.get("content-type", "").startswith(
+                    "application/json"
+                ):
+                    return resp.json()
+                return {}
+            except httpx.HTTPError as e:
+                logger.warning(f"Sample-bucket install failed on {host}: {e}")
+                last_error = e
+
+    error_msg = f"Sample-bucket install failed on all hosts: {hosts}"
+    if last_error:
+        error_msg += f". Last error: {last_error}"
+    logger.error(error_msg)
+    raise RuntimeError(error_msg)

--- a/src/cb_mcp/utils/index_ddl.py
+++ b/src/cb_mcp/utils/index_ddl.py
@@ -1,0 +1,116 @@
+"""
+Index DDL safety primitives.
+
+Identifier quoting and statement allow-listing for the index-management
+tools. These guard the two paths by which a caller can reach index DDL:
+
+1. Structured helper fields (bucket/scope/collection/index names, key
+   fields). Every identifier is backtick-quoted via :func:`safe_ident`
+   before interpolation, so a name containing a backtick cannot break out
+   of its quoting and inject arbitrary SQL++.
+
+2. A raw ``statement`` string. This is convenient but dangerous, so it is
+   constrained by :func:`assert_index_create_ddl` /
+   :func:`assert_index_drop_ddl`, which reject anything that is not the
+   expected index-DDL shape. This prevents the raw path from becoming a
+   general SQL++ execution channel that bypasses read-only and
+   admin-write gating.
+
+License: MIT - Copyright (c) 2026 Chris Ahrendt
+"""
+
+import re
+
+# Allow-list patterns for the raw ``statement`` path. Anchored at the start so
+# a statement must *begin* with the permitted keyword. Note the anchor alone is
+# not sufficient: a statement like "CREATE INDEX ... ; DELETE FROM ..." begins
+# with a permitted keyword but carries a second statement. ``_is_single_statement``
+# below rejects any embedded statement separator so the raw path cannot be used
+# to smuggle a trailing DML/DDL statement past the allow-list.
+_INDEX_CREATE_RE = re.compile(
+    r"""^\s*
+    (
+        CREATE\s+(PRIMARY\s+)?INDEX
+        | CREATE\s+(?:HYPERSCALE\s+|COMPOSITE\s+)?VECTOR\s+INDEX
+    )
+    \b
+    """,
+    re.IGNORECASE | re.VERBOSE,
+)
+
+_INDEX_BUILD_RE = re.compile(r"""^\s*BUILD\s+INDEX\b""", re.IGNORECASE | re.VERBOSE)
+
+_INDEX_DROP_RE = re.compile(
+    r"""^\s*DROP\s+((PRIMARY|VECTOR)\s+)?INDEX\b""",
+    re.IGNORECASE | re.VERBOSE,
+)
+
+
+def _is_single_statement(statement: str) -> bool:
+    """True if *statement* contains no embedded statement separator.
+
+    SQL++ separates statements with ``;``. A trailing semicolon (optionally
+    followed by whitespace) is allowed; a semicolon with anything non-blank
+    after it means a second statement is present and the input is rejected.
+    Backtick-quoted identifiers may legitimately contain a ``;`` inside the
+    quotes, so those spans are removed before the check to avoid false
+    positives on names like ``` `weird;name` ```.
+    """
+    # Strip backtick-quoted spans (identifiers) so a ';' inside a quoted name
+    # is not mistaken for a statement separator. Doubled backticks are escapes.
+    without_idents = re.sub(r"`(?:[^`]|``)*`", "", statement)
+    stripped = without_idents.rstrip()
+    if stripped.endswith(";"):
+        stripped = stripped[:-1]
+    return ";" not in stripped
+
+
+def safe_ident(segment: str) -> str:
+    """Backtick-quote and escape an identifier for SQL++.
+
+    Couchbase SQL++ escapes an embedded backtick by doubling it, so a
+    caller-supplied name can never terminate its own quoting. Applied to
+    every bucket / scope / collection / index / field name before it is
+    interpolated into a statement.
+    """
+    return "`" + (segment or "").replace("`", "``") + "`"
+
+
+def assert_index_create_ddl(statement: str) -> str | None:
+    """Return an error message if *statement* is not permitted index-create DDL.
+
+    Returns ``None`` when the statement is a single CREATE INDEX / CREATE
+    PRIMARY INDEX / CREATE [HYPERSCALE|COMPOSITE] VECTOR INDEX statement. Any
+    other SQL++ - including a permitted statement followed by a second,
+    smuggled statement - is rejected so the raw ``statement`` path cannot be
+    used to run arbitrary queries or DML. (BUILD INDEX is handled by
+    ``build_deferred_indexes``, not this create path.)
+    """
+    stmt = statement or ""
+    if not _INDEX_CREATE_RE.match(stmt) or not _is_single_statement(stmt):
+        return (
+            "The `statement` parameter only accepts a single index-create DDL "
+            "statement (CREATE INDEX, CREATE PRIMARY INDEX, or CREATE "
+            "[HYPERSCALE|COMPOSITE] VECTOR INDEX), with no trailing statement. "
+            "Use the helper fields (index_name, bucket_name, fields, etc.) for "
+            "structured creation, or run other SQL++ via run_sql_plus_plus_query."
+        )
+    return None
+
+
+def assert_index_drop_ddl(statement: str) -> str | None:
+    """Return an error message if *statement* is not permitted index-drop DDL.
+
+    Returns ``None`` when the statement is a single DROP INDEX, DROP PRIMARY
+    INDEX, or DROP VECTOR INDEX statement. Any other SQL++ - including a
+    trailing smuggled statement - is rejected.
+    """
+    stmt = statement or ""
+    if not _INDEX_DROP_RE.match(stmt) or not _is_single_statement(stmt):
+        return (
+            "The `statement` parameter only accepts a single DROP INDEX, DROP "
+            "PRIMARY INDEX, or DROP VECTOR INDEX statement, with no trailing "
+            "statement. Use the helper fields for structured drops, or run "
+            "other SQL++ via run_sql_plus_plus_query."
+        )
+    return None

--- a/src/cb_mcp/utils/index_settings.py
+++ b/src/cb_mcp/utils/index_settings.py
@@ -1,0 +1,155 @@
+"""
+REST client for the Global Secondary Index (GSI) settings endpoint.
+
+The GSI Settings API is served by the cluster manager on port 8091 (18091
+for TLS) at ``/settings/indexes`` - distinct from the Index Service REST API
+(port 9102) used by ``fetch_indexes_from_rest_api`` in ``index_utils``. GET
+returns a JSON object of current settings; POST accepts
+``application/x-www-form-urlencoded`` key-value pairs and leaves unspecified
+parameters unchanged.
+
+Verified against Couchbase Server docs (rest-api/get-settings-indexes,
+post-settings-indexes, rest-index-service) 2026-07-02.
+
+This helper reuses the connection-string host extraction and SSL
+verification logic already present in ``index_utils`` so behavior (Capella
+root CA handling, multi-host fallback, TLS detection) stays consistent with
+the existing index REST path.
+
+License: MIT - Copyright (c) 2026 Chris Ahrendt
+"""
+
+import logging
+from typing import Any
+
+import httpx
+
+from .constants import MCP_SERVER_NAME
+from .index_utils import (
+    _determine_ssl_verification,
+    _extract_hosts_from_connection_string,
+)
+
+logger = logging.getLogger(f"{MCP_SERVER_NAME}.utils.index_settings")
+
+# Cluster-manager ports for the GSI Settings API (NOT the 9102 Index Service
+# port used for /getIndexStatus).
+_GSI_SETTINGS_PORT = 8091
+_GSI_SETTINGS_TLS_PORT = 18091
+_GSI_SETTINGS_PATH = "/settings/indexes"
+
+
+def _settings_base(connection_string: str) -> tuple[str, int]:
+    """Return (scheme, port) for the GSI settings endpoint."""
+    is_tls = connection_string.lower().startswith("couchbases://")
+    return ("https", _GSI_SETTINGS_TLS_PORT) if is_tls else ("http", _GSI_SETTINGS_PORT)
+
+
+def get_gsi_settings(
+    connection_string: str,
+    username: str,
+    password: str,
+    ca_cert_path: str | None = None,
+    timeout: int = 30,
+) -> dict[str, Any]:
+    """GET the current GSI settings from the cluster.
+
+    Tries each host in the connection string until one responds. Raises
+    ``RuntimeError`` if all hosts fail.
+    """
+    return _request_gsi_settings(
+        method="GET",
+        connection_string=connection_string,
+        username=username,
+        password=password,
+        ca_cert_path=ca_cert_path,
+        timeout=timeout,
+    )
+
+
+def set_gsi_settings(
+    connection_string: str,
+    username: str,
+    password: str,
+    params: dict[str, Any],
+    ca_cert_path: str | None = None,
+    timeout: int = 30,
+) -> dict[str, Any]:
+    """POST GSI settings (form-urlencoded) and return the resulting settings.
+
+    ``params`` values are converted to the string forms the endpoint expects
+    (booleans as lowercase ``true``/``false``). Only the supplied keys are
+    sent; unspecified settings are left unchanged by the server. After a
+    successful POST the current settings are read back and returned.
+    """
+    if not params:
+        raise ValueError("params must contain at least one setting to update")
+
+    form = {k: _form_value(v) for k, v in params.items() if v is not None}
+    if not form:
+        raise ValueError("params contained no non-null settings to update")
+
+    _request_gsi_settings(
+        method="POST",
+        connection_string=connection_string,
+        username=username,
+        password=password,
+        ca_cert_path=ca_cert_path,
+        timeout=timeout,
+        data=form,
+    )
+    # Read back so the caller sees the applied state.
+    return get_gsi_settings(
+        connection_string, username, password, ca_cert_path, timeout
+    )
+
+
+def _form_value(value: Any) -> str:
+    """Render a value for the form-urlencoded body (bools lowercased)."""
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    return str(value)
+
+
+def _request_gsi_settings(
+    *,
+    method: str,
+    connection_string: str,
+    username: str,
+    password: str,
+    ca_cert_path: str | None,
+    timeout: int,
+    data: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    """Issue a GET/POST to /settings/indexes, trying each host in turn."""
+    hosts = _extract_hosts_from_connection_string(connection_string)
+    scheme, port = _settings_base(connection_string)
+    verify_ssl = _determine_ssl_verification(connection_string, ca_cert_path)
+
+    last_error: Exception | None = None
+    with httpx.Client(verify=verify_ssl, timeout=timeout) as client:
+        for host in hosts:
+            url = f"{scheme}://{host}:{port}{_GSI_SETTINGS_PATH}"
+            try:
+                logger.info(f"{method} {url}")
+                if method == "GET":
+                    resp = client.get(url, auth=(username, password))
+                else:
+                    resp = client.post(url, data=data, auth=(username, password))
+                resp.raise_for_status()
+                # GET returns settings JSON; POST returns an empty/!json body
+                # on some versions, so only parse when there is content.
+                if resp.content and resp.headers.get("content-type", "").startswith(
+                    "application/json"
+                ):
+                    return resp.json()
+                return {}
+            except httpx.HTTPError as e:
+                logger.warning(f"GSI settings {method} failed on {host}: {e}")
+                last_error = e
+
+    error_msg = f"GSI settings {method} failed on all hosts: {hosts}"
+    if last_error:
+        error_msg += f". Last error: {last_error}"
+    logger.error(error_msg)
+    raise RuntimeError(error_msg)

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -86,6 +86,13 @@ logger = logging.getLogger(MCP_SERVER_NAME)
     help="Enable read-only mode. When True, all write operations (KV and Query) are disabled and KV write tools are not loaded. Set to False to enable write operations.",
 )
 @click.option(
+    "--admin-write-mode",
+    envvar="CB_MCP_ADMIN_WRITE_MODE",
+    type=bool,
+    default=False,
+    help="Enable admin write tools (index DDL and GSI settings). Requires read-only mode to be False. When False, cluster-structure and index-settings mutation tools are not loaded even if data (KV) writes are enabled.",
+)
+@click.option(
     "--transport",
     envvar=[
         "CB_MCP_TRANSPORT"
@@ -212,6 +219,7 @@ def main(
     client_cert_path,
     client_key_path,
     read_only_mode,
+    admin_write_mode,
     transport,
     host,
     port,
@@ -260,6 +268,7 @@ def main(
         disabled_tools=disabled_tools,
         confirmation_required_tools=confirmation_required_tools,
         enforce_scopes=auth is not None,
+        admin_write_mode=admin_write_mode,
     )
 
     # CLI-resolved configuration lives on AppContext, not in a module global.
@@ -272,6 +281,7 @@ def main(
         "client_cert_path": client_cert_path,
         "client_key_path": client_key_path,
         "read_only_mode": read_only_mode,
+        "admin_write_mode": admin_write_mode,
         "transport": transport,
         "host": host,
         "port": port,
@@ -298,7 +308,8 @@ def main(
         """Build the lifespan AppContext with settings captured from the CLI."""
         logger.info(
             f"MCP server initialized in lazy mode for tool discovery. "
-            f"Modes: (read_only_mode={read_only_mode})"
+            f"Modes: (read_only_mode={read_only_mode}, "
+            f"admin_write_mode={admin_write_mode})"
         )
         # Diagnostic snapshot for customer support. Filtered at INFO; visible
         # whenever the user runs with --log-level DEBUG.
@@ -329,7 +340,8 @@ def main(
     mcp = FastMCP(MCP_SERVER_NAME, lifespan=app_lifespan, auth=auth)
 
     logger.info(
-        f"Registering {len(final_tools)} tool(s) with modes (read_only_mode={read_only_mode})"
+        f"Registering {len(final_tools)} tool(s) with modes "
+        f"(read_only_mode={read_only_mode}, admin_write_mode={admin_write_mode})"
     )
 
     # Register tools; FastMCP 3.x add_tool has no annotations kwarg, so wrap first.

--- a/tests/unit/test_bucket_admin.py
+++ b/tests/unit/test_bucket_admin.py
@@ -1,0 +1,519 @@
+"""
+Unit tests for the bucket-management tool bodies (parameter validation,
+argument construction, confirmation gates, and write-scope gating),
+exercised against stubbed REST helpers so no live Couchbase cluster is
+required.
+
+License: MIT - Copyright (c) 2026 Chris Ahrendt
+"""
+
+import json
+from contextlib import contextmanager
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from cb_mcp.tools.bucket_admin import (
+    _require_write_scope,
+    compact_bucket,
+    create_bucket,
+    delete_bucket,
+    flush_bucket,
+    load_sample_bucket,
+    update_bucket,
+)
+from cb_mcp.utils import bucket_admin_rest
+from cb_mcp.utils.bucket_admin_rest import (
+    ALLOWED_COMPACT_ACTIONS,
+    ALLOWED_SAMPLE_BUCKETS,
+    _encode_path_segment,
+    _form_value,
+    assert_bucket_name,
+    validate_extra_bucket_keys,
+)
+from cb_mcp.utils.constants import SCOPE_WRITE
+
+# --------------------------------------------------------------------------
+# Fixtures / helpers
+# --------------------------------------------------------------------------
+
+
+@contextmanager
+def _mock_token(scopes):
+    """Patch get_access_token at the bucket_admin call site.
+
+    Pass a list of scopes for an authenticated token, or None for no token
+    (stdio / OAuth disabled).
+    """
+
+    class _Tok:
+        def __init__(self, scopes_):
+            self.scopes = scopes_
+
+    token = _Tok(scopes) if scopes is not None else None
+    with patch("cb_mcp.tools.bucket_admin.get_access_token", return_value=token):
+        yield
+
+
+def _ctx(**overrides):
+    """Build a Context-shaped SimpleNamespace with default settings."""
+    settings = {
+        "connection_string": "couchbase://localhost",
+        "username": "Administrator",
+        "password": "password",
+        "ca_cert_path": None,
+    }
+    settings.update(overrides)
+    lifespan = SimpleNamespace(settings=settings)
+    request = SimpleNamespace(lifespan_context=lifespan)
+    return SimpleNamespace(request_context=request)
+
+
+def _stub_httpx_client():
+    """Return an httpx.Client stub that always returns 200 OK JSON."""
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.content = b'{"ok":true}'
+    resp.headers = {"content-type": "application/json"}
+    resp.json.return_value = {"ok": True}
+    resp.raise_for_status = MagicMock()
+
+    client = MagicMock()
+    client.get.return_value = resp
+    client.post.return_value = resp
+    client.delete.return_value = resp
+
+    ctx_mgr = MagicMock()
+    ctx_mgr.__enter__.return_value = client
+    ctx_mgr.__exit__.return_value = False
+    return ctx_mgr, client
+
+
+CTX = _ctx()
+
+
+# --------------------------------------------------------------------------
+# assert_bucket_name
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "name",
+    ["travel-sample", "my_bucket", "b1", "A.B_C-D%E", "b" * 100],
+)
+def test_assert_bucket_name_accepts_valid(name):
+    assert_bucket_name(name)
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "",
+        "x" * 101,
+        "bucket/../etc",
+        "bucket/name",
+        "bucket\\name",
+        "bucket name",
+    ],
+)
+def test_assert_bucket_name_rejects_invalid(name):
+    with pytest.raises(ValueError, match="Invalid bucket name"):
+        assert_bucket_name(name)
+
+
+def test_assert_bucket_name_rejects_non_string():
+    with pytest.raises(ValueError, match="Invalid bucket name"):
+        assert_bucket_name(None)
+    with pytest.raises(ValueError, match="Invalid bucket name"):
+        assert_bucket_name(123)
+
+
+# --------------------------------------------------------------------------
+# validate_extra_bucket_keys
+# --------------------------------------------------------------------------
+
+
+def test_validate_extra_bucket_keys_accepts_known():
+    allowed = frozenset({"ramQuota", "replicaNumber"})
+    validate_extra_bucket_keys({"ramQuota": 256, "replicaNumber": 1}, allowed)
+
+
+def test_validate_extra_bucket_keys_rejects_unknown():
+    allowed = frozenset({"ramQuota"})
+    with pytest.raises(ValueError, match=r"Unknown bucket setting key"):
+        validate_extra_bucket_keys({"ramQuota": 256, "bogus": 1}, allowed)
+
+
+def test_validate_extra_bucket_keys_accepts_empty_extra():
+    validate_extra_bucket_keys({}, frozenset({"ramQuota"}))
+
+
+# --------------------------------------------------------------------------
+# _form_value
+# --------------------------------------------------------------------------
+
+
+def test_form_value_bool_lowercased():
+    assert _form_value(True) == "true"
+    assert _form_value(False) == "false"
+
+
+def test_form_value_int():
+    assert _form_value(256) == "256"
+    assert _form_value(0) == "0"
+
+
+def test_form_value_str():
+    assert _form_value("magma") == "magma"
+
+
+def test_form_value_dict_json_encoded():
+    v = _form_value({"parallelDBAndViewCompaction": True})
+    assert json.loads(v) == {"parallelDBAndViewCompaction": True}
+
+
+# --------------------------------------------------------------------------
+# _encode_path_segment (URL path safety for bucket names containing %)
+# --------------------------------------------------------------------------
+
+
+def test_encode_path_segment_percent_encoded_slashes():
+    """A bucket name of '%2f%2e%2e' (URL-encoded '/../') is legal per
+    Couchbase docs (% is a permitted character), but must be double-encoded
+    when placed in a URL path so the server can't route on the decoded form.
+    """
+    assert _encode_path_segment("%2f%2e%2e") == "%252f%252e%252e"
+
+
+def test_encode_path_segment_normal_names_unchanged():
+    for name in ("travel-sample", "b1", "my_bucket", "with.dots"):
+        assert _encode_path_segment(name) == name
+
+
+# --------------------------------------------------------------------------
+# _require_write_scope
+# --------------------------------------------------------------------------
+
+
+def test_require_write_scope_noop_without_token():
+    with _mock_token(None):
+        _require_write_scope()
+
+
+def test_require_write_scope_raises_when_missing():
+    with _mock_token(["read"]), pytest.raises(PermissionError, match="write"):
+        _require_write_scope()
+
+
+def test_require_write_scope_passes_when_present():
+    with _mock_token(["read", SCOPE_WRITE]):
+        _require_write_scope()
+
+
+# --------------------------------------------------------------------------
+# create_bucket
+# --------------------------------------------------------------------------
+
+
+def test_create_bucket_requires_name_or_body():
+    with _mock_token(None), pytest.raises(ValueError, match="bucket_name is required"):
+        create_bucket(CTX, ram_quota_mb=256)
+
+
+def test_create_bucket_requires_ram_quota_when_structured():
+    with _mock_token(None), pytest.raises(ValueError, match="ram_quota_mb is required"):
+        create_bucket(CTX, bucket_name="b1")
+
+
+def test_create_bucket_body_name_mismatch_rejected():
+    with _mock_token(None), pytest.raises(ValueError, match="does not match"):
+        create_bucket(
+            CTX,
+            bucket_name="b1",
+            body={"name": "b2", "ramQuota": 256},
+        )
+
+
+def test_create_bucket_body_invalid_key_rejected():
+    with _mock_token(None), pytest.raises(ValueError, match="Unknown bucket setting"):
+        create_bucket(
+            CTX,
+            body={"name": "b1", "ramQuota": 256, "bogusKey": "x"},
+        )
+
+
+def test_create_bucket_maps_snake_to_camel(monkeypatch):
+    captured = {}
+    monkeypatch.setattr(
+        "cb_mcp.tools.bucket_admin.create_bucket_rest",
+        lambda **kwargs: captured.update(kwargs) or {},
+    )
+    with _mock_token(None):
+        result = create_bucket(
+            CTX,
+            bucket_name="b1",
+            ram_quota_mb=256,
+            bucket_type="membase",
+            storage_backend="magma",
+            replica_number=1,
+            flush_enabled=True,
+            durability_min_level="majority",
+        )
+    form = captured["form"]
+    assert form["name"] == "b1"
+    assert form["ramQuota"] == 256
+    assert form["bucketType"] == "membase"
+    assert form["storageBackend"] == "magma"
+    assert form["replicaNumber"] == 1
+    assert form["flushEnabled"] is True
+    assert form["durabilityMinLevel"] == "majority"
+    assert result["body"]["name"] == "b1"
+
+
+def test_create_bucket_extra_forwarded_after_validation(monkeypatch):
+    captured = {}
+    monkeypatch.setattr(
+        "cb_mcp.tools.bucket_admin.create_bucket_rest",
+        lambda **kwargs: captured.update(kwargs) or {},
+    )
+    with _mock_token(None):
+        create_bucket(
+            CTX,
+            bucket_name="b1",
+            ram_quota_mb=256,
+            extra={"maxTTL": 3600},
+        )
+    assert captured["form"]["maxTTL"] == 3600
+
+
+# --------------------------------------------------------------------------
+# update_bucket
+# --------------------------------------------------------------------------
+
+
+def test_update_bucket_requires_at_least_one_change():
+    with _mock_token(None), pytest.raises(ValueError, match="at least one field"):
+        update_bucket(CTX, bucket_name="b1")
+
+
+def test_update_bucket_rejects_invalid_bucket_name():
+    with _mock_token(None), pytest.raises(ValueError, match="Invalid bucket name"):
+        update_bucket(CTX, bucket_name="b/../etc", ram_quota_mb=256)
+
+
+def test_update_bucket_maps_snake_to_camel(monkeypatch):
+    captured = {}
+    monkeypatch.setattr(
+        "cb_mcp.tools.bucket_admin.update_bucket_rest",
+        lambda **kwargs: captured.update(kwargs) or {},
+    )
+    with _mock_token(None):
+        update_bucket(
+            CTX,
+            bucket_name="b1",
+            ram_quota_mb=512,
+            replica_number=2,
+        )
+    assert captured["form"] == {"ramQuota": 512, "replicaNumber": 2}
+    assert captured["bucket_name"] == "b1"
+
+
+# --------------------------------------------------------------------------
+# delete_bucket
+# --------------------------------------------------------------------------
+
+
+def test_delete_bucket_requires_confirm_true():
+    with _mock_token(None), pytest.raises(ValueError, match="confirm=True"):
+        delete_bucket(CTX, bucket_name="b1")
+
+
+def test_delete_bucket_requires_matching_confirm_name():
+    with _mock_token(None), pytest.raises(ValueError, match="confirm_name"):
+        delete_bucket(CTX, bucket_name="b1", confirm=True, confirm_name="b2")
+
+
+def test_delete_bucket_requires_confirm_name_explicitly():
+    """confirm_name=None is not the same as matching the bucket name."""
+    with _mock_token(None), pytest.raises(ValueError, match="confirm_name"):
+        delete_bucket(CTX, bucket_name="b1", confirm=True)
+
+
+def test_delete_bucket_succeeds_with_matching_confirm_name(monkeypatch):
+    monkeypatch.setattr(
+        "cb_mcp.tools.bucket_admin.delete_bucket_rest",
+        lambda **_: {"ok": True},
+    )
+    with _mock_token(None):
+        result = delete_bucket(CTX, bucket_name="b1", confirm=True, confirm_name="b1")
+    assert result == {"bucket": "b1", "deleted": True, "result": {"ok": True}}
+
+
+# --------------------------------------------------------------------------
+# flush_bucket
+# --------------------------------------------------------------------------
+
+
+def test_flush_bucket_requires_confirm_true():
+    with _mock_token(None), pytest.raises(ValueError, match="confirm=True"):
+        flush_bucket(CTX, bucket_name="b1")
+
+
+def test_flush_bucket_succeeds_with_confirm(monkeypatch):
+    monkeypatch.setattr("cb_mcp.tools.bucket_admin.flush_bucket_rest", lambda **_: {})
+    with _mock_token(None):
+        result = flush_bucket(CTX, bucket_name="b1", confirm=True)
+    assert result["flushed"] is True
+
+
+# --------------------------------------------------------------------------
+# compact_bucket
+# --------------------------------------------------------------------------
+
+
+def test_compact_bucket_default_action_is_start(monkeypatch):
+    captured = {}
+    monkeypatch.setattr(
+        "cb_mcp.tools.bucket_admin.compact_bucket_rest",
+        lambda **kwargs: captured.update(kwargs) or {},
+    )
+    with _mock_token(None):
+        compact_bucket(CTX, bucket_name="b1")
+    assert captured["action"] == "start"
+
+
+def test_compact_bucket_cancel_allowed(monkeypatch):
+    captured = {}
+    monkeypatch.setattr(
+        "cb_mcp.tools.bucket_admin.compact_bucket_rest",
+        lambda **kwargs: captured.update(kwargs) or {},
+    )
+    with _mock_token(None):
+        compact_bucket(CTX, bucket_name="b1", action="cancel")
+    assert captured["action"] == "cancel"
+
+
+def test_compact_bucket_rejects_unknown_action():
+    with _mock_token(None), pytest.raises(ValueError, match="action must be one of"):
+        compact_bucket(CTX, bucket_name="b1", action="pause")
+
+
+def test_compact_actions_allow_list_matches():
+    """The tool's action allow-list must match the REST layer's."""
+    assert frozenset({"start", "cancel"}) == ALLOWED_COMPACT_ACTIONS
+
+
+# --------------------------------------------------------------------------
+# load_sample_bucket
+# --------------------------------------------------------------------------
+
+
+def test_load_sample_bucket_rejects_unknown_sample():
+    with (
+        _mock_token(None),
+        pytest.raises(ValueError, match="sample_name must be one of"),
+    ):
+        load_sample_bucket(CTX, sample_name="my-own-sample")
+
+
+def test_load_sample_bucket_accepts_travel_sample(monkeypatch):
+    monkeypatch.setattr(
+        "cb_mcp.tools.bucket_admin.load_sample_bucket_rest",
+        lambda **_: {},
+    )
+    with _mock_token(None):
+        result = load_sample_bucket(CTX, sample_name="travel-sample")
+    assert result["sample"] == "travel-sample"
+
+
+def test_sample_bucket_allow_list_documented_set():
+    """Documented Couchbase sample buckets 7.x/8.x. Guarding against
+    accidental additions/removals."""
+    assert (
+        frozenset({"travel-sample", "beer-sample", "gamesim-sample"})
+        == ALLOWED_SAMPLE_BUCKETS
+    )
+
+
+# --------------------------------------------------------------------------
+# REST layer URL construction (httpx stubbed)
+# --------------------------------------------------------------------------
+
+
+def test_delete_bucket_rest_url_and_method(monkeypatch):
+    ctx_mgr, client = _stub_httpx_client()
+    monkeypatch.setattr(bucket_admin_rest.httpx, "Client", lambda **_: ctx_mgr)
+
+    bucket_admin_rest.delete_bucket_rest(
+        connection_string="couchbase://localhost",
+        username="u",
+        password="p",
+        bucket_name="b1",
+    )
+    url = client.delete.call_args.args[0]
+    assert url.endswith("/pools/default/buckets/b1")
+    assert url.startswith("http://")
+
+
+def test_tls_connection_string_uses_https_and_18091(monkeypatch):
+    ctx_mgr, client = _stub_httpx_client()
+    monkeypatch.setattr(bucket_admin_rest.httpx, "Client", lambda **_: ctx_mgr)
+
+    bucket_admin_rest.delete_bucket_rest(
+        connection_string="couchbases://mycluster",
+        username="u",
+        password="p",
+        bucket_name="b1",
+    )
+    url = client.delete.call_args.args[0]
+    assert url.startswith("https://")
+    assert ":18091/" in url
+
+
+def test_flush_rest_hits_correct_controller_path(monkeypatch):
+    ctx_mgr, client = _stub_httpx_client()
+    monkeypatch.setattr(bucket_admin_rest.httpx, "Client", lambda **_: ctx_mgr)
+
+    bucket_admin_rest.flush_bucket_rest(
+        connection_string="couchbase://localhost",
+        username="u",
+        password="p",
+        bucket_name="b1",
+    )
+    url = client.post.call_args.args[0]
+    assert url.endswith("/pools/default/buckets/b1/controller/doFlush")
+
+
+@pytest.mark.parametrize(
+    "action,controller",
+    [("start", "compactBucket"), ("cancel", "cancelBucketCompaction")],
+)
+def test_compact_start_vs_cancel_paths(monkeypatch, action, controller):
+    ctx_mgr, client = _stub_httpx_client()
+    monkeypatch.setattr(bucket_admin_rest.httpx, "Client", lambda **_: ctx_mgr)
+
+    bucket_admin_rest.compact_bucket_rest(
+        connection_string="couchbase://localhost",
+        username="u",
+        password="p",
+        bucket_name="b1",
+        action=action,
+    )
+    url = client.post.call_args.args[0]
+    assert url.endswith(f"/pools/default/buckets/b1/controller/{controller}")
+
+
+def test_load_sample_rest_posts_json_array(monkeypatch):
+    ctx_mgr, client = _stub_httpx_client()
+    monkeypatch.setattr(bucket_admin_rest.httpx, "Client", lambda **_: ctx_mgr)
+
+    bucket_admin_rest.load_sample_bucket_rest(
+        connection_string="couchbase://localhost",
+        username="u",
+        password="p",
+        sample_name="travel-sample",
+    )
+    call_kwargs = client.post.call_args.kwargs
+    assert json.loads(call_kwargs["content"]) == ["travel-sample"]
+    assert call_kwargs["headers"]["content-type"] == "application/json"

--- a/tests/unit/test_index_admin_tools_unit.py
+++ b/tests/unit/test_index_admin_tools_unit.py
@@ -1,0 +1,211 @@
+"""
+Unit tests for the index-management tool bodies (statement construction and
+write-scope gating), exercised against stubbed cluster and token modules so
+no live Couchbase cluster is required.
+
+License: MIT - Copyright (c) 2026 Chris Ahrendt
+"""
+
+from contextlib import contextmanager
+from unittest.mock import patch
+
+import pytest
+
+from cb_mcp.tools.index_admin import (
+    build_deferred_indexes,
+    create_index,
+    drop_index,
+)
+
+
+@contextmanager
+def _mock_token(scopes):
+    """Patch get_access_token at the index_admin call site.
+
+    Pass a list of scopes for an authenticated token, or None for no token
+    (stdio / OAuth disabled).
+    """
+
+    class _Tok:
+        def __init__(self, scopes_):
+            self.scopes = scopes_
+
+    token = _Tok(scopes) if scopes is not None else None
+    with patch("cb_mcp.tools.index_admin.get_access_token", return_value=token):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def _stub_cluster_query(monkeypatch):
+    """Patch run_cluster_query at the index_admin call site so statement
+    construction can be tested without a live cluster. Records nothing;
+    tests assert on the returned ``statement`` field the tool echoes back."""
+    monkeypatch.setattr(
+        "cb_mcp.tools.index_admin.run_cluster_query",
+        lambda ctx, statement, **kw: [{"ok": True}],
+    )
+    yield
+
+
+CTX = object()  # tools never introspect ctx directly; they pass it through
+
+
+# --------------------------------------------------------------------------
+# create_index - structured path
+# --------------------------------------------------------------------------
+
+
+def test_create_secondary_index_builds_expected_statement():
+    out = create_index(
+        CTX,
+        index_name="idx_name",
+        bucket_name="travel-sample",
+        scope_name="inventory",
+        collection_name="airline",
+        fields=["name", "country"],
+    )
+    assert out["statement"] == (
+        "CREATE INDEX `idx_name` ON "
+        "`travel-sample`.`inventory`.`airline` (`name`, `country`)"
+    )
+
+
+def test_create_primary_index_with_name():
+    out = create_index(CTX, index_name="pk", bucket_name="b", is_primary=True)
+    assert out["statement"] == "CREATE PRIMARY INDEX `pk` ON `b`.`_default`.`_default`"
+
+
+def test_create_primary_index_without_name():
+    out = create_index(CTX, bucket_name="b", is_primary=True)
+    assert out["statement"] == "CREATE PRIMARY INDEX ON `b`.`_default`.`_default`"
+
+
+def test_create_with_num_replica_and_defer():
+    out = create_index(
+        CTX,
+        index_name="i",
+        bucket_name="b",
+        fields=["x"],
+        num_replica=2,
+        defer_build=True,
+    )
+    assert out["statement"].endswith('WITH {"num_replica": 2, "defer_build": true}')
+
+
+def test_create_missing_bucket_raises():
+    with pytest.raises(ValueError, match="bucket_name is required"):
+        create_index(CTX, index_name="i", fields=["x"])
+
+
+def test_create_secondary_missing_fields_raises():
+    with pytest.raises(ValueError, match="fields are required"):
+        create_index(CTX, index_name="i", bucket_name="b")
+
+
+def test_create_secondary_missing_name_raises():
+    with pytest.raises(ValueError, match="index_name is required"):
+        create_index(CTX, bucket_name="b", fields=["x"])
+
+
+# --------------------------------------------------------------------------
+# create_index - raw statement path
+# --------------------------------------------------------------------------
+
+
+def test_create_raw_statement_allowed():
+    out = create_index(CTX, statement="CREATE INDEX i ON b.s.c (x)")
+    assert out["statement"] == "CREATE INDEX i ON b.s.c (x)"
+
+
+def test_create_raw_statement_rejected():
+    with pytest.raises(ValueError, match="index-create DDL"):
+        create_index(CTX, statement="DELETE FROM b.s.c")
+
+
+# --------------------------------------------------------------------------
+# drop_index
+# --------------------------------------------------------------------------
+
+
+def test_drop_secondary_index_statement():
+    out = drop_index(
+        CTX, index_name="i", bucket_name="b", scope_name="s", collection_name="c"
+    )
+    assert out["statement"] == "DROP INDEX `i` ON `b`.`s`.`c`"
+
+
+def test_drop_primary_index_statement():
+    out = drop_index(CTX, bucket_name="b", is_primary=True)
+    assert out["statement"] == "DROP PRIMARY INDEX ON `b`.`_default`.`_default`"
+
+
+def test_drop_raw_statement_rejected():
+    with pytest.raises(ValueError, match="DROP INDEX"):
+        drop_index(CTX, statement="DROP SCOPE b.s")
+
+
+def test_drop_missing_name_raises():
+    with pytest.raises(ValueError, match="index_name is required"):
+        drop_index(CTX, bucket_name="b")
+
+
+# --------------------------------------------------------------------------
+# build_deferred_indexes
+# --------------------------------------------------------------------------
+
+
+def test_build_bucket_level():
+    out = build_deferred_indexes(CTX, bucket_name="b", index_names=["i1", "i2"])
+    assert out["statement"] == "BUILD INDEX ON `b` (`i1`, `i2`)"
+
+
+def test_build_collection_level():
+    out = build_deferred_indexes(
+        CTX,
+        bucket_name="b",
+        index_names=["i1"],
+        scope_name="s",
+        collection_name="c",
+    )
+    assert out["statement"] == "BUILD INDEX ON `b`.`s`.`c` (`i1`)"
+
+
+def test_build_partial_keyspace_raises():
+    with pytest.raises(ValueError, match="must be provided together"):
+        build_deferred_indexes(CTX, bucket_name="b", index_names=["i"], scope_name="s")
+
+
+def test_build_empty_names_raises():
+    with pytest.raises(ValueError, match="at least one"):
+        build_deferred_indexes(CTX, bucket_name="b", index_names=[])
+
+
+# --------------------------------------------------------------------------
+# write-scope gating (mirrors run_sql_plus_plus_query semantics)
+# --------------------------------------------------------------------------
+
+
+def test_no_token_allows_write():
+    # stdio / OAuth disabled: no token in context -> no scope enforcement
+    with _mock_token(None):
+        out = create_index(CTX, bucket_name="b", is_primary=True)
+    assert out["statement"].startswith("CREATE PRIMARY INDEX")
+
+
+def test_token_with_write_scope_allows():
+    with _mock_token(["couchbase-mcp:write"]):
+        out = drop_index(CTX, bucket_name="b", is_primary=True)
+    assert out["statement"].startswith("DROP PRIMARY INDEX")
+
+
+def test_token_without_write_scope_denied():
+    with (
+        _mock_token(["couchbase-mcp:read"]),
+        pytest.raises(PermissionError, match="requires the 'couchbase-mcp:write'"),
+    ):
+        create_index(CTX, bucket_name="b", is_primary=True)
+
+
+def test_build_denied_without_write_scope():
+    with _mock_token([]), pytest.raises(PermissionError):
+        build_deferred_indexes(CTX, bucket_name="b", index_names=["i"])

--- a/tests/unit/test_index_ddl_unit.py
+++ b/tests/unit/test_index_ddl_unit.py
@@ -1,0 +1,151 @@
+"""
+Unit tests for index DDL safety primitives and statement construction.
+
+These run without a Couchbase cluster: they exercise the pure logic
+(identifier quoting, statement allow-listing, statement building) and the
+write-scope check via a stubbed access token. The cluster execution path
+(``run_cluster_query``) is monkeypatched.
+
+License: MIT - Copyright (c) 2026 Chris Ahrendt
+"""
+
+import pytest
+
+from cb_mcp.utils.index_ddl import (
+    assert_index_create_ddl,
+    assert_index_drop_ddl,
+    safe_ident,
+)
+
+# --------------------------------------------------------------------------
+# safe_ident
+# --------------------------------------------------------------------------
+
+
+def test_safe_ident_wraps_in_backticks():
+    assert safe_ident("users") == "`users`"
+
+
+def test_safe_ident_doubles_embedded_backtick():
+    # A name containing a backtick must not be able to terminate its quoting.
+    assert safe_ident("we`ird") == "`we``ird`"
+
+
+def test_safe_ident_handles_empty_and_none():
+    assert safe_ident("") == "``"
+    assert safe_ident(None) == "``"
+
+
+def test_safe_ident_injection_attempt_is_neutralized():
+    # Attempt to break out and append a DROP; the backtick is doubled so the
+    # whole thing stays a single (absurd) identifier.
+    malicious = "x` ON b.s.c; DROP INDEX `y"
+    quoted = safe_ident(malicious)
+    assert quoted.startswith("`") and quoted.endswith("`")
+    # No unescaped backtick remains that could close the identifier early.
+    inner = quoted[1:-1]
+    assert "``" in inner
+    assert not any(
+        inner[i] == "`" and inner[i - 1] != "`" and inner[i + 1 : i + 2] != "`"
+        for i in range(1, len(inner) - 1)
+    )
+
+
+# --------------------------------------------------------------------------
+# assert_index_create_ddl
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "stmt",
+    [
+        "CREATE INDEX idx ON b.s.c (name)",
+        "create index idx on b.s.c (name)",
+        "CREATE PRIMARY INDEX ON b.s.c",
+        "  CREATE   PRIMARY   INDEX ON b.s.c",
+        "CREATE VECTOR INDEX v ON b.s.c (emb VECTOR)",
+        "CREATE HYPERSCALE VECTOR INDEX v ON b.s.c (emb VECTOR)",
+        "CREATE COMPOSITE VECTOR INDEX v ON b.s.c (emb VECTOR)",
+    ],
+)
+def test_create_ddl_allows_index_statements(stmt):
+    assert assert_index_create_ddl(stmt) is None
+
+
+@pytest.mark.parametrize(
+    "stmt",
+    [
+        "SELECT * FROM b.s.c",
+        "DELETE FROM b.s.c",
+        "UPDATE b.s.c SET x = 1",
+        "DROP INDEX idx ON b.s.c",
+        "INSERT INTO b.s.c VALUES (1, {})",
+        "CREATE SCOPE b.s",
+        "CREATE COLLECTION b.s.c",
+        "",
+        "   ",
+        "; CREATE INDEX idx ON b.s.c (name)",  # leading junk before keyword
+        "BUILD INDEX ON b.s.c (i)",  # BUILD routes to build_deferred_indexes
+        # multi-statement injection: permitted head + smuggled tail
+        "CREATE INDEX i ON b.s.c (x); DELETE FROM b.s.c WHERE 1=1",
+        "CREATE PRIMARY INDEX ON b.s.c ; DROP SCOPE b.s",
+        "CREATE INDEX i ON b.s.c (x);SELECT 1",
+    ],
+)
+def test_create_ddl_rejects_non_index_statements(stmt):
+    msg = assert_index_create_ddl(stmt)
+    assert msg is not None
+    assert "index-create DDL" in msg
+
+
+def test_create_ddl_handles_none():
+    assert assert_index_create_ddl(None) is not None
+
+
+@pytest.mark.parametrize(
+    "stmt",
+    [
+        "CREATE INDEX i ON b.s.c (name);",  # single trailing semicolon
+        "CREATE INDEX i ON b.s.c (name)  ;  ",  # trailing semicolon + whitespace
+        "CREATE INDEX `weird;name` ON b.s.c (x)",  # ';' inside a quoted ident
+    ],
+)
+def test_create_ddl_allows_trailing_semicolon_and_quoted_semicolon(stmt):
+    assert assert_index_create_ddl(stmt) is None
+
+
+# --------------------------------------------------------------------------
+# assert_index_drop_ddl
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "stmt",
+    [
+        "DROP INDEX idx ON b.s.c",
+        "drop index idx on b.s.c",
+        "DROP PRIMARY INDEX ON b.s.c",
+        "DROP VECTOR INDEX v ON b.s.c",
+        "  DROP   INDEX idx ON b.s.c",
+    ],
+)
+def test_drop_ddl_allows_drop_statements(stmt):
+    assert assert_index_drop_ddl(stmt) is None
+
+
+@pytest.mark.parametrize(
+    "stmt",
+    [
+        "CREATE INDEX idx ON b.s.c (name)",
+        "SELECT * FROM b.s.c",
+        "DELETE FROM b.s.c",
+        "DROP SCOPE b.s",
+        "DROP COLLECTION b.s.c",
+        "DROP PRIMARY VECTOR INDEX ON b.s.c",  # not a real statement shape
+        "DROP INDEX i ON b.s.c; CREATE PRIMARY INDEX ON b.s.c",  # injection
+        "",
+        None,
+    ],
+)
+def test_drop_ddl_rejects_non_drop_statements(stmt):
+    assert assert_index_drop_ddl(stmt) is not None

--- a/tests/unit/test_index_settings_unit.py
+++ b/tests/unit/test_index_settings_unit.py
@@ -1,0 +1,186 @@
+"""
+Unit tests for the GSI settings tools and REST helper pure logic.
+
+The tools' network calls (get_gsi_settings / set_gsi_settings) are
+monkeypatched so these tests exercise parameter mapping and gating without a
+cluster. The REST helper's pure functions (_form_value, _settings_base) are
+tested directly.
+
+License: MIT - Copyright (c) 2026 Chris Ahrendt
+"""
+
+from contextlib import contextmanager
+from unittest.mock import patch
+
+import pytest
+
+from cb_mcp.tools import index_admin
+from cb_mcp.utils import index_settings
+
+
+@contextmanager
+def _mock_token(scopes):
+    class _Tok:
+        def __init__(self, scopes_):
+            self.scopes = scopes_
+
+    token = _Tok(scopes) if scopes is not None else None
+    with patch("cb_mcp.tools.index_admin.get_access_token", return_value=token):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def _stub_get_settings(monkeypatch):
+    """Patch get_settings so settings tools don't require a live AppContext."""
+    monkeypatch.setattr(
+        "cb_mcp.tools.index_admin.get_settings",
+        lambda ctx: {
+            "connection_string": "couchbase://localhost",
+            "username": "u",
+            "password": "p",
+            "ca_cert_path": None,
+        },
+    )
+    yield
+
+
+CTX = object()
+
+
+# --------------------------------------------------------------------------
+# REST helper pure logic
+# --------------------------------------------------------------------------
+
+
+def test_form_value_bools_lowercased():
+    assert index_settings._form_value(True) == "true"
+    assert index_settings._form_value(False) == "false"
+
+
+def test_form_value_ints_and_strings():
+    assert index_settings._form_value(4) == "4"
+    assert index_settings._form_value("plasma") == "plasma"
+
+
+def test_settings_base_non_tls():
+    assert index_settings._settings_base("couchbase://localhost") == ("http", 8091)
+
+
+def test_settings_base_tls():
+    assert index_settings._settings_base("couchbases://cb.example") == (
+        "https",
+        18091,
+    )
+
+
+def test_set_gsi_settings_rejects_empty():
+    with pytest.raises(ValueError, match="at least one setting"):
+        index_settings.set_gsi_settings("couchbase://h", "u", "p", params={})
+
+
+def test_set_gsi_settings_rejects_all_none():
+    with pytest.raises(ValueError, match="no non-null settings"):
+        index_settings.set_gsi_settings(
+            "couchbase://h", "u", "p", params={"numReplica": None}
+        )
+
+
+# --------------------------------------------------------------------------
+# admin_index_settings_get
+# --------------------------------------------------------------------------
+
+
+def test_settings_get_returns_settings(monkeypatch):
+    captured = {}
+
+    def fake_get(**kwargs):
+        captured.update(kwargs)
+        return {"indexerThreads": 4, "logLevel": "info"}
+
+    monkeypatch.setattr(index_admin, "get_gsi_settings", fake_get)
+    out = index_admin.admin_index_settings_get(CTX)
+    assert out == {"indexerThreads": 4, "logLevel": "info"}
+    assert captured["connection_string"] == "couchbase://localhost"
+
+
+# --------------------------------------------------------------------------
+# admin_index_settings_set - param mapping
+# --------------------------------------------------------------------------
+
+
+def test_settings_set_maps_named_params(monkeypatch):
+    captured = {}
+
+    def fake_set(**kwargs):
+        captured.update(kwargs)
+        return {"applied": True}
+
+    monkeypatch.setattr(index_admin, "set_gsi_settings", fake_set)
+    index_admin.admin_index_settings_set(
+        CTX,
+        indexer_threads=8,
+        log_level="verbose",
+        redistribute_indexes=False,
+    )
+    assert captured["params"] == {
+        "indexerThreads": 8,
+        "logLevel": "verbose",
+        "redistributeIndexes": False,
+    }
+
+
+def test_settings_set_merges_extra(monkeypatch):
+    captured = {}
+    monkeypatch.setattr(
+        index_admin,
+        "set_gsi_settings",
+        lambda **kw: captured.update(kw) or {},
+    )
+    # extra keys must be documented camelCase GSI keys; enableShardAffinity is
+    # valid but has no named parameter in an older tool version, so it is a
+    # representative forward-compat use of the escape hatch.
+    index_admin.admin_index_settings_set(
+        CTX, num_replica=2, extra={"enableShardAffinity": True}
+    )
+    assert captured["params"] == {"numReplica": 2, "enableShardAffinity": True}
+
+
+def test_settings_set_rejects_unknown_extra_key(monkeypatch):
+    monkeypatch.setattr(index_admin, "set_gsi_settings", lambda **kw: {})
+    with pytest.raises(ValueError, match="Unknown GSI setting key"):
+        index_admin.admin_index_settings_set(CTX, extra={"arbitraryKey": "x"})
+
+
+def test_settings_set_requires_at_least_one(monkeypatch):
+    monkeypatch.setattr(index_admin, "set_gsi_settings", lambda **kw: {})
+    with pytest.raises(ValueError, match="at least one setting"):
+        index_admin.admin_index_settings_set(CTX)
+
+
+def test_settings_set_omits_none_values(monkeypatch):
+    captured = {}
+    monkeypatch.setattr(
+        index_admin,
+        "set_gsi_settings",
+        lambda **kw: captured.update(kw) or {},
+    )
+    index_admin.admin_index_settings_set(CTX, storage_mode="plasma")
+    assert captured["params"] == {"storageMode": "plasma"}
+
+
+# --------------------------------------------------------------------------
+# write-scope gating on set (get is read-only, not gated)
+# --------------------------------------------------------------------------
+
+
+def test_settings_set_denied_without_write_scope(monkeypatch):
+    monkeypatch.setattr(index_admin, "set_gsi_settings", lambda **kw: {})
+    with _mock_token(["couchbase-mcp:read"]), pytest.raises(PermissionError):
+        index_admin.admin_index_settings_set(CTX, indexer_threads=4)
+
+
+def test_settings_set_allowed_with_write_scope(monkeypatch):
+    monkeypatch.setattr(index_admin, "set_gsi_settings", lambda **kw: {"ok": True})
+    with _mock_token(["couchbase-mcp:write"]):
+        out = index_admin.admin_index_settings_set(CTX, indexer_threads=4)
+    assert out == {"ok": True}

--- a/tests/unit/test_read_only_mode.py
+++ b/tests/unit/test_read_only_mode.py
@@ -24,7 +24,7 @@ KV_WRITE_TOOL_NAMES = {
     "delete_document_by_id",
 }
 
-# Read-only tool names that should always be available (20 tools)
+# Read-only tool names that should always be available (21 tools)
 READ_ONLY_TOOL_NAMES = {
     # Server/Cluster management tools (7)
     "get_buckets_in_cluster",
@@ -43,6 +43,8 @@ READ_ONLY_TOOL_NAMES = {
     # Index tools (2)
     "get_index_advisor_recommendations",
     "list_indexes",
+    # Index settings read tool (1)
+    "admin_index_settings_get",
     # Query performance analysis tools (7)
     "get_queries_not_selective",
     "get_queries_not_using_covering_index",
@@ -157,13 +159,13 @@ class TestToolCounts:
         """Verify correct number of tools in read-only mode."""
         tools = get_tools(read_only_mode=True)
         assert len(tools) == len(READ_ONLY_TOOLS)
-        assert len(tools) == 20  # Expected count of read-only tools
+        assert len(tools) == 21  # Expected count of read-only tools
 
     def test_all_tools_mode_tool_count(self):
         """Verify correct number of tools when all write tools are enabled."""
         tools = get_tools(read_only_mode=False)
         assert len(tools) == len(ALL_TOOLS)
-        assert len(tools) == 24  # Expected total count (20 read-only + 4 KV write)
+        assert len(tools) == 25  # Expected total count (21 read-only + 4 KV write)
 
     def test_kv_write_tools_count(self):
         """Verify exactly 4 KV write tools exist."""


### PR DESCRIPTION
> ⚠️ **This PR stacks on top of #187.** Its diff includes both #187's index-management code and this PR's bucket-management code because #187 is still under review and its branch doesn't exist on upstream. Once #187 merges, GitHub will auto-shrink this diff to just the 4 new bucket-admin files:
> - `src/cb_mcp/tools/bucket_admin.py`
> - `src/cb_mcp/tools/__init__.py` (registration additions)
> - `src/cb_mcp/utils/bucket_admin_rest.py`
> - `tests/unit/test_bucket_admin.py`
>
> If you'd like to review just the bucket-management changes in isolation before #187 lands, view the diff at: https://github.com/celticht32/mcp-server-couchbase/compare/feat/index-management-tools...feat/bucket-management-tools

Phase 2 of the phased admin-tool contribution discussed in #157. Follows the same shape and safety model as #187.

## What this adds

Six tools that complete the bucket lifecycle the server currently only reads (`get_buckets_in_cluster` shows them; these create, update, and destroy them):

- `create_bucket` — POST `/pools/default/buckets`. Structured fields (name + ram_quota_mb + optional bucket_type / storage_backend / replica_number / eviction_policy / flush_enabled / durability_min_level / etc.) or a raw `body` dict. Both paths run through the same allow-listed key validator.
- `update_bucket` — POST `/pools/default/buckets/{name}`. Same shape as create; create-only fields (bucket_type, storage_backend, conflict_resolution_type, num_vbuckets) intentionally omitted.
- `delete_bucket` — DELETE `/pools/default/buckets/{name}`. **Requires both `confirm=True` and `confirm_name` matching the target bucket exactly** — matches the Couchbase Web Console "type the bucket name to delete" pattern.
- `flush_bucket` — POST `.../controller/doFlush`. Requires `confirm=True`. Server enforces `flushEnabled=true` on the bucket separately.
- `compact_bucket` — POST `.../controller/compactBucket` or `.../controller/cancelBucketCompaction` per `action="start"|"cancel"`.
- `load_sample_bucket` — POST `/sampleBuckets/install` with a JSON array. Sample name allow-listed against the documented set (`travel-sample`, `beer-sample`, `gamesim-sample`).

REST goes through a new `utils/bucket_admin_rest.py` helper that reuses `_extract_hosts_from_connection_string` and `_determine_ssl_verification` from `utils/index_utils.py` — same pattern `utils/index_settings.py` uses in #187, so multi-host fallback, TLS detection, and Capella root-CA handling stay consistent.

## Why it's shaped this way

Follows the conventions #187 established:

- `ctx`-first tool functions, dict returns, raise on error, registration via `tools/__init__.py` lists + `TOOL_ANNOTATIONS`.
- Reuses `ADMIN_WRITE_TOOLS` — bucket lifecycle loads only when `read_only_mode` is false AND `admin_write_mode` is true. Bucket create/delete is at least as privileged as index DDL.
- Same `_require_write_scope()` shape as `index_admin.py`. When an OAuth token is present the caller must additionally hold the write scope.
- Structured args AND raw `body` dict, both validated against the same allow-list of documented REST form keys. A permitted key set cannot be smuggled around: unknown keys are rejected before the request is built.
- All identifiers going into URL paths (`bucket_name`, sample-install target) are validated against the documented Couchbase bucket-name charset (`[A-Za-z0-9._%-]{1,100}`) AND then URL-encoded via `_encode_path_segment` before interpolation. `%` is a valid bucket-name character per Couchbase docs, so a name like `%2f%2e%2e` passes the charset check; encoding it before insertion makes sure the server can't route on the decoded form.
- `compact_bucket`'s controller path is chosen from a small allow-list (`{"start", "cancel"}` → `compactBucket` / `cancelBucketCompaction`) rather than accepting an arbitrary controller name.
- `load_sample_bucket`'s sample name is validated against the documented sample-bucket allow-list.
- Booleans render as lowercase `"true"`/`"false"` in the form body (Couchbase REST rejects Python's `str(True)`). Dicts render as JSON (for `autoCompactionSettings` etc.). Ints render bare.

## Testing

Unit tests in `tests/unit/test_bucket_admin.py` (no cluster required): bucket-name validator (charset, length, non-string, path-traversal characters), extra-key allow-list, form-value rendering (bool/int/dict), write-scope gate (present / missing / no-token), argument construction (snake→camel mapping), confirm-gate coverage (delete requires `confirm=True` AND matching `confirm_name`; flush requires `confirm=True`), REST URL construction (correct method, correct path per endpoint, TLS uses https+18091), URL path encoding (`%2f%2e%2e` → `%252f%252e%252e`), and allow-list matching between the tool and REST layers.

- `ruff check` and `ruff format --check` pass against pinned ruff 0.12.5.
- Full unit suite green — 477 tests pass (existing 425 + 52 new).
- Tested on Python 3.10 syntax (`ast.parse` with `feature_version=(3, 10)`).

## Open questions for maintainers

Same three from #187 apply here; happy to align with whatever you decide on that PR:

1. **Naming.** Verb-first for the write ops (`create_bucket`, `delete_bucket`, etc.) to match #187's `create_index` / `drop_index`. No `admin_bucket_settings_*` because bucket settings ARE the bucket — `update_bucket` covers that surface.
2. **Admin-write flag.** These load under the same `--admin-write-mode` / `CB_MCP_ADMIN_WRITE_MODE` flag #187 introduced. If you decide to collapse that into `read_only_mode` on #187, I'll follow suit here.
3. **Error convention.** Same raised-exception shape as #187. Structured `ok()`/`err()` envelope deferred to a future PR (best done uniformly at the registration layer).

Refs #157, #187.