### PR TITLE
Add diagnostics tools + SENSITIVE_READ_TOOLS category (11 tools)

### DIFF
--- a/src/cb_mcp/tool_registration.py
+++ b/src/cb_mcp/tool_registration.py
@@ -5,7 +5,7 @@ Tool registration orchestration shared across MCP implementations.
 import logging
 from collections.abc import Callable
 
-from .tools import KV_WRITE_TOOLS, get_tools
+from .tools import ADMIN_WRITE_TOOLS, KV_WRITE_TOOLS, get_tools
 from .utils.config import parse_tool_names
 from .utils.constants import MCP_SERVER_NAME
 from .utils.elicitation import wrap_with_confirmation
@@ -23,6 +23,7 @@ def prepare_tools_for_registration(
     disabled_tools: str | None,
     confirmation_required_tools: str | None,
     enforce_scopes: bool = False,
+    admin_write_mode: bool = False,
 ) -> tuple[list[Callable], set[str], set[str]]:
     """Prepare final tool list and confirmation configuration for registration.
 
@@ -36,8 +37,9 @@ def prepare_tools_for_registration(
     (stdio / unauthenticated), so ``enforce_scopes`` only affects whether
     the wrapper is installed — not whether it does work per call.
     """
-    # When read_only_mode is True, KV write tools are not loaded.
-    tools = get_tools(read_only_mode=read_only_mode)
+    # When read_only_mode is True, KV write tools are not loaded. Admin write
+    # tools (index DDL, GSI settings) additionally require admin_write_mode.
+    tools = get_tools(read_only_mode=read_only_mode, admin_write_mode=admin_write_mode)
 
     loaded_tool_names = {tool.__name__ for tool in tools}
     disabled_tool_names = parse_tool_names(disabled_tools, loaded_tool_names)
@@ -74,7 +76,7 @@ def prepare_tools_for_registration(
             f"{sorted(skipped_confirmation_tool_names)}"
         )
 
-    write_tool_names = {fn.__name__ for fn in KV_WRITE_TOOLS}
+    write_tool_names = {fn.__name__ for fn in (*KV_WRITE_TOOLS, *ADMIN_WRITE_TOOLS)}
 
     final_tools: list[Callable] = []
     for tool in enabled_tools:

--- a/src/cb_mcp/tools/__init__.py
+++ b/src/cb_mcp/tools/__init__.py
@@ -22,6 +22,20 @@ from .collections_admin import (
     update_collection,
 )
 
+# FTS (Full-Text Search) admin tools (index lifecycle + control)
+from .fts_admin import (
+    analyze_document,
+    create_fts_index,
+    delete_fts_index,
+    get_fts_index,
+    get_fts_index_count,
+    list_fts_indexes,
+    pause_fts_index_ingest,
+    resume_fts_index_ingest,
+    set_fts_index_query_control,
+    update_fts_index,
+)
+
 # Index tools
 from .index import get_index_advisor_recommendations, list_indexes
 
@@ -110,6 +124,11 @@ READ_ONLY_TOOLS = [
     list_remote_clusters,
     list_replications,
     get_replication_settings,
+    # FTS read tools
+    list_fts_indexes,
+    get_fts_index,
+    get_fts_index_count,
+    analyze_document,
     # Query performance analysis tools
     get_queries_not_selective,
     get_queries_not_using_covering_index,
@@ -150,6 +169,12 @@ ADMIN_WRITE_TOOLS = [
     pause_replication,
     resume_replication,
     update_replication_settings,
+    create_fts_index,
+    update_fts_index,
+    delete_fts_index,
+    pause_fts_index_ingest,
+    resume_fts_index_ingest,
+    set_fts_index_query_control,
 ]
 
 # List of all tools for easy registration (kept for backward compatibility)
@@ -222,6 +247,24 @@ TOOL_ANNOTATIONS: dict[str, ToolAnnotations] = {
     "update_replication_settings": ToolAnnotations(
         destructiveHint=False, idempotentHint=True
     ),
+    # FTS read tools
+    "list_fts_indexes": ToolAnnotations(readOnlyHint=True),
+    "get_fts_index": ToolAnnotations(readOnlyHint=True),
+    "get_fts_index_count": ToolAnnotations(readOnlyHint=True),
+    "analyze_document": ToolAnnotations(readOnlyHint=True),
+    # FTS write tools
+    "create_fts_index": ToolAnnotations(idempotentHint=False),
+    "update_fts_index": ToolAnnotations(destructiveHint=False, idempotentHint=True),
+    "delete_fts_index": ToolAnnotations(destructiveHint=True, idempotentHint=True),
+    "pause_fts_index_ingest": ToolAnnotations(
+        destructiveHint=False, idempotentHint=True
+    ),
+    "resume_fts_index_ingest": ToolAnnotations(
+        destructiveHint=False, idempotentHint=True
+    ),
+    "set_fts_index_query_control": ToolAnnotations(
+        destructiveHint=False, idempotentHint=True
+    ),
 }
 
 
@@ -290,6 +333,16 @@ __all__ = [
     "pause_replication",
     "resume_replication",
     "update_replication_settings",
+    "list_fts_indexes",
+    "get_fts_index",
+    "get_fts_index_count",
+    "analyze_document",
+    "create_fts_index",
+    "update_fts_index",
+    "delete_fts_index",
+    "pause_fts_index_ingest",
+    "resume_fts_index_ingest",
+    "set_fts_index_query_control",
     "get_cluster_health_and_services",
     "get_queries_not_selective",
     "get_queries_not_using_covering_index",

--- a/src/cb_mcp/tools/__init__.py
+++ b/src/cb_mcp/tools/__init__.py
@@ -22,6 +22,21 @@ from .collections_admin import (
     update_collection,
 )
 
+# Diagnostics: cluster stats, node info, per-service stats, slow queries, logs
+from .diagnostics import (
+    get_bucket_stats,
+    get_cluster_info,
+    get_cluster_stats,
+    get_disk_usage,
+    get_error_logs,
+    get_fts_stats,
+    get_index_stats,
+    get_kv_stats,
+    get_node_info,
+    get_query_stats,
+    get_slow_queries,
+)
+
 # FTS (Full-Text Search) admin tools (index lifecycle + control)
 from .fts_admin import (
     analyze_document,
@@ -129,6 +144,16 @@ READ_ONLY_TOOLS = [
     get_fts_index,
     get_fts_index_count,
     analyze_document,
+    # Diagnostics (read-only)
+    get_cluster_info,
+    get_cluster_stats,
+    get_node_info,
+    get_bucket_stats,
+    get_index_stats,
+    get_query_stats,
+    get_fts_stats,
+    get_kv_stats,
+    get_disk_usage,
     # Query performance analysis tools
     get_queries_not_selective,
     get_queries_not_using_covering_index,
@@ -175,6 +200,18 @@ ADMIN_WRITE_TOOLS = [
     pause_fts_index_ingest,
     resume_fts_index_ingest,
     set_fts_index_query_control,
+]
+
+# Sensitive read tools - loaded only when admin_write_mode=True. These are
+# READ-ONLY operations but return data that can include user query text,
+# server log entries with connection strings/hostnames, and other content
+# with a higher exposure profile than ordinary stats. Gating them behind
+# the same flag as admin writes lets operators run the server in a
+# lower-privilege mode (KV writes on, admin writes off) while still
+# blocking access to potentially-sensitive read data.
+SENSITIVE_READ_TOOLS = [
+    get_slow_queries,
+    get_error_logs,
 ]
 
 # List of all tools for easy registration (kept for backward compatibility)
@@ -265,6 +302,19 @@ TOOL_ANNOTATIONS: dict[str, ToolAnnotations] = {
     "set_fts_index_query_control": ToolAnnotations(
         destructiveHint=False, idempotentHint=True
     ),
+    # Diagnostics (read-only)
+    "get_cluster_info": ToolAnnotations(readOnlyHint=True),
+    "get_cluster_stats": ToolAnnotations(readOnlyHint=True),
+    "get_node_info": ToolAnnotations(readOnlyHint=True),
+    "get_bucket_stats": ToolAnnotations(readOnlyHint=True),
+    "get_index_stats": ToolAnnotations(readOnlyHint=True),
+    "get_query_stats": ToolAnnotations(readOnlyHint=True),
+    "get_fts_stats": ToolAnnotations(readOnlyHint=True),
+    "get_kv_stats": ToolAnnotations(readOnlyHint=True),
+    "get_disk_usage": ToolAnnotations(readOnlyHint=True),
+    # Sensitive reads
+    "get_slow_queries": ToolAnnotations(readOnlyHint=True),
+    "get_error_logs": ToolAnnotations(readOnlyHint=True),
 }
 
 
@@ -281,8 +331,17 @@ def get_tools(
       cluster-wide index settings are a higher privilege than data writes, so
       disabling read-only alone does not expose them; an operator must also
       opt in to admin writes.
+    - SENSITIVE_READ_TOOLS load whenever admin_write_mode is True (independent
+      of read_only_mode). These are reads that return data with a higher
+      exposure profile (query text with literal values, server logs); gating
+      them behind admin_write_mode keeps them out of the default profile
+      while still letting an operator running in read-only mode enable
+      diagnostics by opting into admin_write_mode.
     """
     tools = list(READ_ONLY_TOOLS)
+
+    if admin_write_mode:
+        tools.extend(SENSITIVE_READ_TOOLS)
 
     if not read_only_mode:
         # KV write tools are only loaded when READ_ONLY_MODE is False
@@ -343,6 +402,17 @@ __all__ = [
     "pause_fts_index_ingest",
     "resume_fts_index_ingest",
     "set_fts_index_query_control",
+    "get_cluster_info",
+    "get_cluster_stats",
+    "get_node_info",
+    "get_bucket_stats",
+    "get_index_stats",
+    "get_query_stats",
+    "get_fts_stats",
+    "get_kv_stats",
+    "get_disk_usage",
+    "get_slow_queries",
+    "get_error_logs",
     "get_cluster_health_and_services",
     "get_queries_not_selective",
     "get_queries_not_using_covering_index",
@@ -355,6 +425,7 @@ __all__ = [
     "READ_ONLY_TOOLS",
     "KV_WRITE_TOOLS",
     "ADMIN_WRITE_TOOLS",
+    "SENSITIVE_READ_TOOLS",
     # Tool annotations
     "TOOL_ANNOTATIONS",
     # Convenience

--- a/src/cb_mcp/tools/__init__.py
+++ b/src/cb_mcp/tools/__init__.py
@@ -68,6 +68,21 @@ from .server import (
     test_cluster_connection,
 )
 
+# XDCR admin tools (remote clusters + replications, write) + list/get reads
+from .xdcr_admin import (
+    create_remote_cluster,
+    create_replication,
+    delete_remote_cluster,
+    delete_replication,
+    get_replication_settings,
+    list_remote_clusters,
+    list_replications,
+    pause_replication,
+    resume_replication,
+    update_remote_cluster,
+    update_replication_settings,
+)
+
 # Read-only tools - always available regardless of mode settings
 READ_ONLY_TOOLS = [
     # Server/Cluster management tools
@@ -91,6 +106,10 @@ READ_ONLY_TOOLS = [
     admin_index_settings_get,
     # Collection settings (read)
     get_collection_settings,
+    # XDCR read tools
+    list_remote_clusters,
+    list_replications,
+    get_replication_settings,
     # Query performance analysis tools
     get_queries_not_selective,
     get_queries_not_using_covering_index,
@@ -123,6 +142,14 @@ ADMIN_WRITE_TOOLS = [
     create_collection,
     drop_collection,
     update_collection,
+    create_remote_cluster,
+    update_remote_cluster,
+    delete_remote_cluster,
+    create_replication,
+    delete_replication,
+    pause_replication,
+    resume_replication,
+    update_replication_settings,
 ]
 
 # List of all tools for easy registration (kept for backward compatibility)
@@ -177,6 +204,24 @@ TOOL_ANNOTATIONS: dict[str, ToolAnnotations] = {
     "update_collection": ToolAnnotations(destructiveHint=False, idempotentHint=True),
     # Collection settings (read)
     "get_collection_settings": ToolAnnotations(readOnlyHint=True),
+    # XDCR read tools
+    "list_remote_clusters": ToolAnnotations(readOnlyHint=True),
+    "list_replications": ToolAnnotations(readOnlyHint=True),
+    "get_replication_settings": ToolAnnotations(readOnlyHint=True),
+    # XDCR remote-cluster tools (write)
+    "create_remote_cluster": ToolAnnotations(idempotentHint=False),
+    "update_remote_cluster": ToolAnnotations(
+        destructiveHint=False, idempotentHint=True
+    ),
+    "delete_remote_cluster": ToolAnnotations(destructiveHint=True, idempotentHint=True),
+    # XDCR replication lifecycle (write)
+    "create_replication": ToolAnnotations(idempotentHint=False),
+    "delete_replication": ToolAnnotations(destructiveHint=True, idempotentHint=True),
+    "pause_replication": ToolAnnotations(destructiveHint=False, idempotentHint=True),
+    "resume_replication": ToolAnnotations(destructiveHint=False, idempotentHint=True),
+    "update_replication_settings": ToolAnnotations(
+        destructiveHint=False, idempotentHint=True
+    ),
 }
 
 
@@ -234,6 +279,17 @@ __all__ = [
     "drop_collection",
     "update_collection",
     "get_collection_settings",
+    "list_remote_clusters",
+    "list_replications",
+    "get_replication_settings",
+    "create_remote_cluster",
+    "update_remote_cluster",
+    "delete_remote_cluster",
+    "create_replication",
+    "delete_replication",
+    "pause_replication",
+    "resume_replication",
+    "update_replication_settings",
     "get_cluster_health_and_services",
     "get_queries_not_selective",
     "get_queries_not_using_covering_index",

--- a/src/cb_mcp/tools/__init__.py
+++ b/src/cb_mcp/tools/__init__.py
@@ -12,6 +12,16 @@ from collections.abc import Callable
 
 from mcp.types import ToolAnnotations
 
+# Scope and collection management tools (write) + get_collection_settings (read)
+from .collections_admin import (
+    create_collection,
+    create_scope,
+    drop_collection,
+    drop_scope,
+    get_collection_settings,
+    update_collection,
+)
+
 # Index tools
 from .index import get_index_advisor_recommendations, list_indexes
 
@@ -79,6 +89,8 @@ READ_ONLY_TOOLS = [
     list_indexes,
     # Index settings (read)
     admin_index_settings_get,
+    # Collection settings (read)
+    get_collection_settings,
     # Query performance analysis tools
     get_queries_not_selective,
     get_queries_not_using_covering_index,
@@ -106,6 +118,11 @@ ADMIN_WRITE_TOOLS = [
     drop_index,
     build_deferred_indexes,
     admin_index_settings_set,
+    create_scope,
+    drop_scope,
+    create_collection,
+    drop_collection,
+    update_collection,
 ]
 
 # List of all tools for easy registration (kept for backward compatibility)
@@ -152,6 +169,14 @@ TOOL_ANNOTATIONS: dict[str, ToolAnnotations] = {
     "admin_index_settings_set": ToolAnnotations(
         destructiveHint=False, idempotentHint=True
     ),
+    # Scope/collection management (write)
+    "create_scope": ToolAnnotations(idempotentHint=False),
+    "drop_scope": ToolAnnotations(destructiveHint=True, idempotentHint=True),
+    "create_collection": ToolAnnotations(idempotentHint=False),
+    "drop_collection": ToolAnnotations(destructiveHint=True, idempotentHint=True),
+    "update_collection": ToolAnnotations(destructiveHint=False, idempotentHint=True),
+    # Collection settings (read)
+    "get_collection_settings": ToolAnnotations(readOnlyHint=True),
 }
 
 
@@ -203,6 +228,12 @@ __all__ = [
     "build_deferred_indexes",
     "admin_index_settings_get",
     "admin_index_settings_set",
+    "create_scope",
+    "drop_scope",
+    "create_collection",
+    "drop_collection",
+    "update_collection",
+    "get_collection_settings",
     "get_cluster_health_and_services",
     "get_queries_not_selective",
     "get_queries_not_using_covering_index",

--- a/src/cb_mcp/tools/__init__.py
+++ b/src/cb_mcp/tools/__init__.py
@@ -15,6 +15,15 @@ from mcp.types import ToolAnnotations
 # Index tools
 from .index import get_index_advisor_recommendations, list_indexes
 
+# Index management tools (DDL + GSI settings, write)
+from .index_admin import (
+    admin_index_settings_get,
+    admin_index_settings_set,
+    build_deferred_indexes,
+    create_index,
+    drop_index,
+)
+
 # Key-Value tools
 from .kv import (
     delete_document_by_id,
@@ -68,6 +77,8 @@ READ_ONLY_TOOLS = [
     # Index tools
     get_index_advisor_recommendations,
     list_indexes,
+    # Index settings (read)
+    admin_index_settings_get,
     # Query performance analysis tools
     get_queries_not_selective,
     get_queries_not_using_covering_index,
@@ -84,6 +95,17 @@ KV_WRITE_TOOLS = [
     insert_document_by_id,
     replace_document_by_id,
     delete_document_by_id,
+]
+
+# Admin write tools - loaded only when read_only_mode is False AND
+# admin_write_mode is True. These mutate cluster structure (index DDL) or
+# cluster-wide index settings, a strictly higher privilege than data writes,
+# so they gate behind a second, independent flag.
+ADMIN_WRITE_TOOLS = [
+    create_index,
+    drop_index,
+    build_deferred_indexes,
+    admin_index_settings_set,
 ]
 
 # List of all tools for easy registration (kept for backward compatibility)
@@ -121,20 +143,39 @@ TOOL_ANNOTATIONS: dict[str, ToolAnnotations] = {
     "insert_document_by_id": ToolAnnotations(idempotentHint=True),
     "replace_document_by_id": ToolAnnotations(idempotentHint=True),
     "delete_document_by_id": ToolAnnotations(destructiveHint=True, idempotentHint=True),
+    # Index management tools (write)
+    "create_index": ToolAnnotations(idempotentHint=False),
+    "drop_index": ToolAnnotations(destructiveHint=True, idempotentHint=True),
+    "build_deferred_indexes": ToolAnnotations(idempotentHint=True),
+    # Index settings
+    "admin_index_settings_get": ToolAnnotations(readOnlyHint=True),
+    "admin_index_settings_set": ToolAnnotations(
+        destructiveHint=False, idempotentHint=True
+    ),
 }
 
 
-def get_tools(read_only_mode: bool = True) -> list[Callable]:
+def get_tools(
+    read_only_mode: bool = True,
+    admin_write_mode: bool = False,
+) -> list[Callable]:
     """Get the list of tools based on the mode settings.
 
-    This function determines which tools should be loaded based on the
-    READ_ONLY_MODE setting. When read_only_mode is True, write tools are excluded.
+    - READ_ONLY_TOOLS are always loaded.
+    - KV_WRITE_TOOLS load when read_only_mode is False.
+    - ADMIN_WRITE_TOOLS load only when read_only_mode is False AND
+      admin_write_mode is True. Cluster-structure mutation (index DDL) and
+      cluster-wide index settings are a higher privilege than data writes, so
+      disabling read-only alone does not expose them; an operator must also
+      opt in to admin writes.
     """
     tools = list(READ_ONLY_TOOLS)
 
     if not read_only_mode:
         # KV write tools are only loaded when READ_ONLY_MODE is False
         tools.extend(KV_WRITE_TOOLS)
+        if admin_write_mode:
+            tools.extend(ADMIN_WRITE_TOOLS)
 
     return tools
 
@@ -157,6 +198,11 @@ __all__ = [
     "explain_sql_plus_plus_query",
     "get_index_advisor_recommendations",
     "list_indexes",
+    "create_index",
+    "drop_index",
+    "build_deferred_indexes",
+    "admin_index_settings_get",
+    "admin_index_settings_set",
     "get_cluster_health_and_services",
     "get_queries_not_selective",
     "get_queries_not_using_covering_index",
@@ -168,6 +214,7 @@ __all__ = [
     # Tool categories
     "READ_ONLY_TOOLS",
     "KV_WRITE_TOOLS",
+    "ADMIN_WRITE_TOOLS",
     # Tool annotations
     "TOOL_ANNOTATIONS",
     # Convenience

--- a/src/cb_mcp/tools/collections_admin.py
+++ b/src/cb_mcp/tools/collections_admin.py
@@ -1,0 +1,416 @@
+"""
+Tools for scope and collection management.
+
+These tools create, update, drop, and read settings for scopes and
+collections within a bucket. They complement the existing read-only
+tools ``get_scopes_in_bucket``, ``get_collections_in_scope``, and
+``get_scopes_and_collections_in_bucket``.
+
+Write gating
+------------
+Scope and collection lifecycle is a per-bucket namespace change. These
+tools are loaded only when the server is *not* in read-only mode AND
+admin-write mode is enabled (see ``tools/__init__.py`` ``get_tools``
+and ``ADMIN_WRITE_TOOLS``). When an OAuth token is present, the caller
+must additionally hold the write scope; this mirrors the scope
+enforcement in ``run_sql_plus_plus_query``.
+
+Drop confirmation
+-----------------
+``drop_scope`` and ``drop_collection`` require both ``confirm=True`` AND
+a ``confirm_name`` that matches the target scope/collection name. This
+is a UX guard against fat-finger destruction; combined with
+admin-write-mode gating and the write-scope check, three independent
+gates precede a drop.
+
+Implementation
+--------------
+This module uses the Couchbase SDK's ``CollectionManager`` for both
+reads and writes so behavior stays consistent with the existing scope
+and collection read tools in ``tools/server.py``. TTL and history-
+retention settings are represented by the SDK's ``CollectionSpec``
+type, which correctly handles the ``max_expiry`` (Couchbase 7.6+) vs.
+``max_ttl`` (7.0 - 7.5) transition per the SDK's compatibility layer.
+
+License: MIT - Copyright (c) 2026 Chris Ahrendt
+"""
+
+import logging
+from datetime import timedelta
+from typing import Any
+
+from couchbase.management.collections import CollectionSpec
+from fastmcp import Context
+from fastmcp.server.dependencies import get_access_token
+
+from ..utils.connection import connect_to_bucket
+from ..utils.constants import MCP_SERVER_NAME, SCOPE_WRITE
+from ..utils.context import get_cluster_connection
+
+logger = logging.getLogger(f"{MCP_SERVER_NAME}.tools.collections_admin")
+
+
+def _require_write_scope() -> None:
+    """Raise ``PermissionError`` if a token is present but lacks the write scope.
+
+    No-op when no token is in context (stdio transport or OAuth disabled),
+    matching the behavior of ``run_sql_plus_plus_query`` so the same tool
+    body serves authenticated HTTP and unauthenticated stdio without
+    branching at registration time.
+    """
+    token = get_access_token()
+    if token is not None and SCOPE_WRITE not in (token.scopes or []):
+        held = sorted(set(token.scopes or []))
+        msg = (
+            f"Scope/collection admin requires the '{SCOPE_WRITE}' scope; "
+            f"token scopes are {held}."
+        )
+        logger.warning(msg)
+        raise PermissionError(msg)
+
+
+def _timedelta_or_none(seconds: int | None) -> timedelta | None:
+    """Convert an optional integer of seconds to timedelta or return None.
+
+    ``0`` maps to ``timedelta(seconds=0)`` explicitly because Couchbase uses
+    it to mean "no TTL" (whereas ``None`` means "leave unchanged" on update).
+    """
+    if seconds is None:
+        return None
+    if seconds < 0:
+        raise ValueError(f"TTL/max_expiry cannot be negative, got {seconds}")
+    return timedelta(seconds=seconds)
+
+
+# --------------------------------------------------------------------------
+# Scope management
+# --------------------------------------------------------------------------
+
+
+def create_scope(
+    ctx: Context,
+    bucket_name: str,
+    scope_name: str,
+) -> dict[str, Any]:
+    """Create a scope within a bucket.
+
+    Both ``bucket_name`` and ``scope_name`` are required. Returns a dict
+    with the created bucket and scope names.
+
+    Fails with ``ScopeAlreadyExistsException`` (from the SDK) if a scope
+    with that name already exists in the bucket.
+    """
+    _require_write_scope()
+
+    cluster = get_cluster_connection(ctx)
+    bucket = connect_to_bucket(cluster, bucket_name)
+    try:
+        logger.info(f"Creating scope {scope_name!r} in bucket {bucket_name!r}")
+        bucket.collections().create_scope(scope_name)
+        return {"bucket": bucket_name, "scope": scope_name, "created": True}
+    except Exception as e:
+        logger.error(
+            f"Error creating scope {scope_name!r} in bucket {bucket_name!r}: {e}",
+            exc_info=True,
+        )
+        raise
+
+
+def drop_scope(
+    ctx: Context,
+    bucket_name: str,
+    scope_name: str,
+    confirm: bool = False,
+    confirm_name: str | None = None,
+) -> dict[str, Any]:
+    """Drop a scope from a bucket. Irreversible; deletes all collections
+    (and thus all documents) in the scope.
+
+    Requires BOTH:
+
+    - ``confirm=True``
+    - ``confirm_name`` set to the exact scope name
+
+    The name-match is a UX guard against fat-finger deletion; combined
+    with the admin-write-mode gate and the OAuth write-scope check,
+    three independent gates precede a drop.
+
+    Cannot drop ``_default`` (Couchbase server rejects it).
+    """
+    _require_write_scope()
+
+    if not confirm:
+        raise ValueError(
+            "drop_scope requires confirm=True. This operation is "
+            "irreversible and deletes every collection and document in "
+            "the scope."
+        )
+    if confirm_name != scope_name:
+        raise ValueError(
+            "drop_scope requires confirm_name to exactly match "
+            f"scope_name ({scope_name!r}). This guard against fat-finger "
+            "deletion matches the delete_bucket pattern."
+        )
+    if scope_name == "_default":
+        raise ValueError(
+            "The _default scope cannot be dropped (Couchbase server "
+            "rejects this operation)."
+        )
+
+    cluster = get_cluster_connection(ctx)
+    bucket = connect_to_bucket(cluster, bucket_name)
+    try:
+        logger.warning(f"Dropping scope {scope_name!r} in bucket {bucket_name!r}")
+        bucket.collections().drop_scope(scope_name)
+        return {"bucket": bucket_name, "scope": scope_name, "dropped": True}
+    except Exception as e:
+        logger.error(
+            f"Error dropping scope {scope_name!r} in bucket {bucket_name!r}: {e}",
+            exc_info=True,
+        )
+        raise
+
+
+# --------------------------------------------------------------------------
+# Collection management
+# --------------------------------------------------------------------------
+
+
+def create_collection(
+    ctx: Context,
+    bucket_name: str,
+    scope_name: str,
+    collection_name: str,
+    max_expiry_seconds: int | None = None,
+    history: bool | None = None,
+) -> dict[str, Any]:
+    """Create a collection inside a scope.
+
+    Required: ``bucket_name``, ``scope_name``, ``collection_name``.
+
+    Optional per-collection settings:
+
+    - ``max_expiry_seconds``: default document TTL in seconds. ``0`` = no
+      TTL (documents don't expire). ``None`` = inherit from the bucket
+      default.
+    - ``history``: enable per-document history retention (Couchbase 7.2+
+      with Magma storage engine). ``None`` = server default.
+
+    Returns a dict with the created keyspace and settings applied.
+    """
+    _require_write_scope()
+
+    spec = CollectionSpec(
+        collection_name=collection_name,
+        scope_name=scope_name,
+        max_expiry=_timedelta_or_none(max_expiry_seconds),
+        history=history,
+    )
+
+    cluster = get_cluster_connection(ctx)
+    bucket = connect_to_bucket(cluster, bucket_name)
+    try:
+        logger.info(f"Creating collection {bucket_name}.{scope_name}.{collection_name}")
+        bucket.collections().create_collection(spec)
+        return {
+            "bucket": bucket_name,
+            "scope": scope_name,
+            "collection": collection_name,
+            "max_expiry_seconds": max_expiry_seconds,
+            "history": history,
+            "created": True,
+        }
+    except Exception as e:
+        logger.error(
+            f"Error creating collection "
+            f"{bucket_name}.{scope_name}.{collection_name}: {e}",
+            exc_info=True,
+        )
+        raise
+
+
+def drop_collection(
+    ctx: Context,
+    bucket_name: str,
+    scope_name: str,
+    collection_name: str,
+    confirm: bool = False,
+    confirm_name: str | None = None,
+) -> dict[str, Any]:
+    """Drop a collection. Irreversible; deletes all documents in the
+    collection.
+
+    Requires BOTH:
+
+    - ``confirm=True``
+    - ``confirm_name`` set to the exact collection name
+
+    The name-match is a UX guard against fat-finger deletion; combined
+    with the admin-write-mode gate and the OAuth write-scope check,
+    three independent gates precede a drop.
+
+    Cannot drop ``_default`` collection from ``_default`` scope (Couchbase
+    server rejects it).
+    """
+    _require_write_scope()
+
+    if not confirm:
+        raise ValueError(
+            "drop_collection requires confirm=True. This operation is "
+            "irreversible and deletes every document in the collection."
+        )
+    if confirm_name != collection_name:
+        raise ValueError(
+            "drop_collection requires confirm_name to exactly match "
+            f"collection_name ({collection_name!r}). This guard against "
+            "fat-finger deletion matches the delete_bucket pattern."
+        )
+    if scope_name == "_default" and collection_name == "_default":
+        raise ValueError(
+            "The _default collection in the _default scope cannot be "
+            "dropped (Couchbase server rejects this operation)."
+        )
+
+    cluster = get_cluster_connection(ctx)
+    bucket = connect_to_bucket(cluster, bucket_name)
+    try:
+        logger.warning(
+            f"Dropping collection {bucket_name}.{scope_name}.{collection_name}"
+        )
+        # The SDK's drop_collection takes a CollectionSpec but only reads
+        # scope_name and collection_name from it, so a minimal spec is fine.
+        spec = CollectionSpec(collection_name=collection_name, scope_name=scope_name)
+        bucket.collections().drop_collection(spec)
+        return {
+            "bucket": bucket_name,
+            "scope": scope_name,
+            "collection": collection_name,
+            "dropped": True,
+        }
+    except Exception as e:
+        logger.error(
+            f"Error dropping collection "
+            f"{bucket_name}.{scope_name}.{collection_name}: {e}",
+            exc_info=True,
+        )
+        raise
+
+
+def update_collection(
+    ctx: Context,
+    bucket_name: str,
+    scope_name: str,
+    collection_name: str,
+    max_expiry_seconds: int | None = None,
+    history: bool | None = None,
+) -> dict[str, Any]:
+    """Update mutable settings on an existing collection.
+
+    Both ``max_expiry_seconds`` and ``history`` are optional; only the
+    values explicitly provided are sent to the server. Passing both as
+    ``None`` (the default) is a no-op — raises an error since the caller
+    likely made a mistake.
+
+    Returns a dict with the settings sent to the server.
+    """
+    _require_write_scope()
+
+    if max_expiry_seconds is None and history is None:
+        raise ValueError(
+            "update_collection requires at least one of "
+            "max_expiry_seconds or history to be provided."
+        )
+
+    spec = CollectionSpec(
+        collection_name=collection_name,
+        scope_name=scope_name,
+        max_expiry=_timedelta_or_none(max_expiry_seconds),
+        history=history,
+    )
+
+    cluster = get_cluster_connection(ctx)
+    bucket = connect_to_bucket(cluster, bucket_name)
+    try:
+        logger.info(f"Updating collection {bucket_name}.{scope_name}.{collection_name}")
+        bucket.collections().update_collection(spec)
+        return {
+            "bucket": bucket_name,
+            "scope": scope_name,
+            "collection": collection_name,
+            "max_expiry_seconds": max_expiry_seconds,
+            "history": history,
+            "updated": True,
+        }
+    except Exception as e:
+        logger.error(
+            f"Error updating collection "
+            f"{bucket_name}.{scope_name}.{collection_name}: {e}",
+            exc_info=True,
+        )
+        raise
+
+
+# --------------------------------------------------------------------------
+# Collection settings read
+# --------------------------------------------------------------------------
+
+
+def get_collection_settings(
+    ctx: Context,
+    bucket_name: str,
+    scope_name: str,
+    collection_name: str,
+) -> dict[str, Any]:
+    """Get the settings for a single collection.
+
+    Returns a dict with:
+
+    - ``bucket``, ``scope``, ``collection``: the keyspace identifiers
+    - ``max_expiry_seconds``: default TTL in seconds; ``0`` = no TTL,
+      ``-1`` = inherit bucket default (per Couchbase 7.6+ semantics),
+      ``None`` = server did not return a value
+    - ``history``: whether per-document history retention is enabled
+
+    Raises ``ValueError`` if the requested scope or collection does not
+    exist in the bucket.
+    """
+    cluster = get_cluster_connection(ctx)
+    bucket = connect_to_bucket(cluster, bucket_name)
+    try:
+        logger.debug(
+            f"Reading settings for {bucket_name}.{scope_name}.{collection_name}"
+        )
+        scopes = bucket.collections().get_all_scopes()
+        for scope in scopes:
+            if scope.name != scope_name:
+                continue
+            for coll in scope.collections:
+                if coll.name != collection_name:
+                    continue
+                # SDK exposes max_expiry as timedelta or None
+                exp = getattr(coll, "max_expiry", None)
+                if isinstance(exp, timedelta):
+                    max_expiry_seconds = int(exp.total_seconds())
+                else:
+                    max_expiry_seconds = None
+                return {
+                    "bucket": bucket_name,
+                    "scope": scope_name,
+                    "collection": collection_name,
+                    "max_expiry_seconds": max_expiry_seconds,
+                    "history": getattr(coll, "history", None),
+                }
+            raise ValueError(
+                f"Collection {collection_name!r} not found in scope "
+                f"{scope_name!r} of bucket {bucket_name!r}"
+            )
+        raise ValueError(f"Scope {scope_name!r} not found in bucket {bucket_name!r}")
+    except ValueError:
+        raise
+    except Exception as e:
+        logger.error(
+            f"Error reading settings for "
+            f"{bucket_name}.{scope_name}.{collection_name}: {e}",
+            exc_info=True,
+        )
+        raise

--- a/src/cb_mcp/tools/diagnostics.py
+++ b/src/cb_mcp/tools/diagnostics.py
@@ -1,0 +1,281 @@
+"""
+Tools for cluster diagnostics and stats.
+
+Eleven read-only tools that surface the same information available in the
+Couchbase cluster manager Web Console but structured for programmatic use
+by an MCP client. Every tool is a GET; nothing here mutates state.
+
+Category split
+--------------
+Nine tools are ordinary read-only (``READ_ONLY_TOOLS``):
+
+- ``get_cluster_info`` — /pools/default (nodes, quotas, storage totals)
+- ``get_cluster_stats`` — a subset of /pools/default focused on
+  operational stats
+- ``get_node_info`` — /nodes/self
+- ``get_bucket_stats`` — per-bucket stats
+- ``get_index_stats`` — index service stats
+- ``get_query_stats`` — query service stats
+- ``get_fts_stats`` — FTS service stats
+- ``get_kv_stats`` — KV curr_items and related
+- ``get_disk_usage`` — synthesized from /pools/default
+
+Two tools land in a new ``SENSITIVE_READ_TOOLS`` category loaded only when
+``admin_write_mode`` is on:
+
+- ``get_slow_queries`` — reads ``system:completed_requests`` which can
+  contain full query text including data values
+- ``get_error_logs`` — recent server log entries which can contain
+  connection strings, hostnames, and internal state
+
+License: MIT - Copyright (c) 2026 Chris Ahrendt
+"""
+
+import logging
+from typing import Any
+
+from fastmcp import Context
+
+from ..utils.config import get_settings
+from ..utils.constants import MCP_SERVER_NAME
+from ..utils.diagnostics_rest import (
+    get_bucket_stats_rest,
+    get_error_logs_rest,
+    get_fts_stats_rest,
+    get_index_stats_rest,
+    get_kv_stats_rest,
+    get_node_self_rest,
+    get_pools_default_rest,
+    get_query_stats_rest,
+)
+from .query import run_cluster_query
+
+logger = logging.getLogger(f"{MCP_SERVER_NAME}.tools.diagnostics")
+
+
+# --------------------------------------------------------------------------
+# READ_ONLY tools
+# --------------------------------------------------------------------------
+
+
+def get_cluster_info(ctx: Context) -> dict[str, Any]:
+    """Get cluster-wide info: node list, quotas, storage totals, running tasks.
+
+    Returns the raw ``/pools/default`` response, which contains everything
+    the Web Console shows on its Overview screen.
+    """
+    settings = get_settings(ctx)
+    return get_pools_default_rest(
+        connection_string=settings["connection_string"],
+        username=settings["username"],
+        password=settings["password"],
+        ca_cert_path=settings.get("ca_cert_path"),
+    )
+
+
+def get_cluster_stats(ctx: Context) -> dict[str, Any]:
+    """Get operational stats from the cluster: nodes count, RAM/disk usage.
+
+    A curated subset of ``get_cluster_info`` focused on operational-stats
+    fields (rather than the full node list and quota configuration).
+    Useful when a caller wants a compact overview without parsing the
+    full /pools/default response.
+    """
+    settings = get_settings(ctx)
+    raw = get_pools_default_rest(
+        connection_string=settings["connection_string"],
+        username=settings["username"],
+        password=settings["password"],
+        ca_cert_path=settings.get("ca_cert_path"),
+    )
+    # Pull the interesting subset. Kept as a dict of the fields that
+    # actually vary at runtime, so a caller can diff them across polls.
+    nodes = raw.get("nodes", []) if isinstance(raw, dict) else []
+    storage_totals = raw.get("storageTotals", {}) if isinstance(raw, dict) else {}
+    return {
+        "node_count": len(nodes),
+        "healthy_nodes": sum(
+            1 for n in nodes if isinstance(n, dict) and n.get("status") == "healthy"
+        ),
+        "storage_totals": storage_totals,
+        "balanced": raw.get("balanced") if isinstance(raw, dict) else None,
+        "rebalance_status": raw.get("rebalanceStatus")
+        if isinstance(raw, dict)
+        else None,
+    }
+
+
+def get_node_info(ctx: Context) -> dict[str, Any]:
+    """Get info for the current node (/nodes/self).
+
+    Returns hostname, uptime, memory used/total, services running, and
+    OS-level counters for the node the connection lands on.
+    """
+    settings = get_settings(ctx)
+    return get_node_self_rest(
+        connection_string=settings["connection_string"],
+        username=settings["username"],
+        password=settings["password"],
+        ca_cert_path=settings.get("ca_cert_path"),
+    )
+
+
+def get_bucket_stats(ctx: Context, bucket_name: str) -> dict[str, Any]:
+    """Get per-bucket runtime stats.
+
+    Returns ops per second, disk queues, memory usage, and cache hit ratio
+    for a single bucket. Ranges from a few seconds to a minute of history
+    depending on cluster load.
+    """
+    settings = get_settings(ctx)
+    return get_bucket_stats_rest(
+        connection_string=settings["connection_string"],
+        username=settings["username"],
+        password=settings["password"],
+        bucket_name=bucket_name,
+        ca_cert_path=settings.get("ca_cert_path"),
+    )
+
+
+def get_index_stats(ctx: Context) -> dict[str, Any]:
+    """Get Index Service runtime stats.
+
+    Returns index count, memory used by the indexer, average scan latency,
+    and per-index timings across the cluster.
+    """
+    settings = get_settings(ctx)
+    return get_index_stats_rest(
+        connection_string=settings["connection_string"],
+        username=settings["username"],
+        password=settings["password"],
+        ca_cert_path=settings.get("ca_cert_path"),
+    )
+
+
+def get_query_stats(ctx: Context) -> dict[str, Any]:
+    """Get Query Service runtime stats.
+
+    Returns request rate, active request count, and average latency for
+    the query engine.
+    """
+    settings = get_settings(ctx)
+    return get_query_stats_rest(
+        connection_string=settings["connection_string"],
+        username=settings["username"],
+        password=settings["password"],
+        ca_cert_path=settings.get("ca_cert_path"),
+    )
+
+
+def get_fts_stats(ctx: Context) -> dict[str, Any]:
+    """Get FTS (Full-Text Search) service runtime stats.
+
+    Reads /api/nsstats on the FTS service port (8094/18094), not the
+    cluster manager. Returns per-index doc counts, query throughput, and
+    indexing pipeline stats.
+    """
+    settings = get_settings(ctx)
+    return get_fts_stats_rest(
+        connection_string=settings["connection_string"],
+        username=settings["username"],
+        password=settings["password"],
+        ca_cert_path=settings.get("ca_cert_path"),
+    )
+
+
+def get_kv_stats(ctx: Context, bucket_name: str) -> dict[str, Any]:
+    """Get KV (data) service stats for a bucket.
+
+    Returns current items count and related KV runtime stats. Requires a
+    bucket name because Couchbase KV stats are bucket-scoped.
+    """
+    settings = get_settings(ctx)
+    return get_kv_stats_rest(
+        connection_string=settings["connection_string"],
+        username=settings["username"],
+        password=settings["password"],
+        bucket_name=bucket_name,
+        ca_cert_path=settings.get("ca_cert_path"),
+    )
+
+
+def get_disk_usage(ctx: Context) -> dict[str, Any]:
+    """Get cluster disk usage totals.
+
+    Extracted from ``/pools/default``'s ``storageTotals`` block. Returns
+    RAM totals plus HDD usage/quota/free per node aggregated at the
+    cluster level.
+    """
+    settings = get_settings(ctx)
+    raw = get_pools_default_rest(
+        connection_string=settings["connection_string"],
+        username=settings["username"],
+        password=settings["password"],
+        ca_cert_path=settings.get("ca_cert_path"),
+    )
+    storage = raw.get("storageTotals", {}) if isinstance(raw, dict) else {}
+    return {
+        "ram": storage.get("ram", {}),
+        "hdd": storage.get("hdd", {}),
+    }
+
+
+# --------------------------------------------------------------------------
+# SENSITIVE_READ tools (loaded only when admin_write_mode=True)
+# --------------------------------------------------------------------------
+
+
+def get_slow_queries(
+    ctx: Context,
+    min_duration_ms: int = 1000,
+    limit: int = 50,
+) -> dict[str, Any]:
+    """Read the ``system:completed_requests`` keyspace for slow queries.
+
+    Returns queries whose ``elapsedTime`` exceeded ``min_duration_ms``,
+    ordered by duration descending, capped at ``limit`` rows.
+
+    Note: this reads real query text which may include literal data
+    values from prior WHERE clauses. That's why it's in
+    ``SENSITIVE_READ_TOOLS`` — the results can contain user data even
+    though the tool itself is read-only.
+    """
+    if min_duration_ms < 0:
+        raise ValueError(f"min_duration_ms cannot be negative, got {min_duration_ms}")
+    if limit < 1 or limit > 1000:
+        raise ValueError(f"limit must be 1-1000, got {limit}")
+
+    # completed_requests stores durations as strings like "1.234s"; the
+    # numeric form is available via STR_TO_DURATION_MS
+    stmt = (
+        "SELECT requestId, statement, elapsedTime, resultCount, "
+        "requestTime, users "
+        "FROM system:completed_requests "
+        f"WHERE STR_TO_DURATION(elapsedTime)/1000000 >= {int(min_duration_ms)} "
+        "ORDER BY elapsedTime DESC "
+        f"LIMIT {int(limit)}"
+    )
+    logger.info(f"Reading slow queries (min={min_duration_ms}ms, limit={limit})")
+    rows = run_cluster_query(ctx, stmt)
+    return {
+        "min_duration_ms": min_duration_ms,
+        "limit": limit,
+        "count": len(rows) if isinstance(rows, list) else 0,
+        "slow_queries": rows,
+    }
+
+
+def get_error_logs(ctx: Context) -> dict[str, Any]:
+    """Get recent server log entries from the cluster manager.
+
+    Returns the same view the Web Console's Logs tab shows. Log entries
+    can contain connection strings, hostnames, and internal state, which
+    is why this tool is in ``SENSITIVE_READ_TOOLS``.
+    """
+    settings = get_settings(ctx)
+    return get_error_logs_rest(
+        connection_string=settings["connection_string"],
+        username=settings["username"],
+        password=settings["password"],
+        ca_cert_path=settings.get("ca_cert_path"),
+    )

--- a/src/cb_mcp/tools/fts_admin.py
+++ b/src/cb_mcp/tools/fts_admin.py
@@ -1,0 +1,354 @@
+"""
+Tools for FTS (Full-Text Search) index administration.
+
+FTS is Couchbase's built-in search service. This module exposes ten tools
+covering the index lifecycle:
+
+- **CRUD**: create, get, list, update, delete
+- **Control**: pause/resume ingestion, allow/disallow queries
+- **Diagnostics**: get document count, analyze a document against a mapping
+
+Write gating
+------------
+Index CRUD and control mutate the FTS service's persistent state. Write
+tools are loaded only when the server is *not* in read-only mode AND
+admin-write mode is enabled (see ``tools/__init__.py`` ``get_tools`` and
+``ADMIN_WRITE_TOOLS``). When an OAuth token is present, the caller must
+additionally hold the write scope; this mirrors the scope enforcement in
+the other admin modules.
+
+Delete confirmation
+-------------------
+``delete_fts_index`` requires BOTH ``confirm=True`` AND a ``confirm_name``
+matching the target index name. This mirrors the pattern established by
+``delete_bucket`` and ``delete_remote_cluster``; combined with the
+admin-write-mode gate and the OAuth write-scope check, three independent
+gates precede a destructive index operation.
+
+License: MIT - Copyright (c) 2026 Chris Ahrendt
+"""
+
+import logging
+from typing import Any
+
+from fastmcp import Context
+from fastmcp.server.dependencies import get_access_token
+
+from ..utils.config import get_settings
+from ..utils.constants import MCP_SERVER_NAME, SCOPE_WRITE
+from ..utils.fts_rest import (
+    analyze_doc_rest,
+    assert_fts_index_name,
+    create_or_update_fts_index_rest,
+    delete_fts_index_rest,
+    get_fts_index_count_rest,
+    get_fts_index_rest,
+    ingest_control_rest,
+    list_fts_indexes_rest,
+    query_control_rest,
+)
+
+logger = logging.getLogger(f"{MCP_SERVER_NAME}.tools.fts_admin")
+
+
+def _require_write_scope() -> None:
+    """Raise ``PermissionError`` if a token is present but lacks the write scope."""
+    token = get_access_token()
+    if token is not None and SCOPE_WRITE not in (token.scopes or []):
+        held = sorted(set(token.scopes or []))
+        msg = f"FTS admin requires the '{SCOPE_WRITE}' scope; token scopes are {held}."
+        logger.warning(msg)
+        raise PermissionError(msg)
+
+
+# --------------------------------------------------------------------------
+# Read tools (READ_ONLY_TOOLS)
+# --------------------------------------------------------------------------
+
+
+def list_fts_indexes(ctx: Context) -> dict[str, Any]:
+    """List all FTS indexes on the cluster.
+
+    Returns the raw response from the FTS service, which is a dict with an
+    ``indexDefs`` key containing per-index definitions.
+    """
+    settings = get_settings(ctx)
+    return list_fts_indexes_rest(
+        connection_string=settings["connection_string"],
+        username=settings["username"],
+        password=settings["password"],
+        ca_cert_path=settings.get("ca_cert_path"),
+    )
+
+
+def get_fts_index(
+    ctx: Context,
+    index_name: str,
+) -> dict[str, Any]:
+    """Get the full definition of an FTS index (mapping, source config,
+    plan params). Read-only.
+    """
+    assert_fts_index_name(index_name)
+    settings = get_settings(ctx)
+    return get_fts_index_rest(
+        connection_string=settings["connection_string"],
+        username=settings["username"],
+        password=settings["password"],
+        index_name=index_name,
+        ca_cert_path=settings.get("ca_cert_path"),
+    )
+
+
+def get_fts_index_count(
+    ctx: Context,
+    index_name: str,
+) -> dict[str, Any]:
+    """Get the document count for an FTS index. Read-only.
+
+    Returns a dict with a ``count`` key; useful for confirming an index has
+    fully ingested its source data before running queries against it.
+    """
+    assert_fts_index_name(index_name)
+    settings = get_settings(ctx)
+    return get_fts_index_count_rest(
+        connection_string=settings["connection_string"],
+        username=settings["username"],
+        password=settings["password"],
+        index_name=index_name,
+        ca_cert_path=settings.get("ca_cert_path"),
+    )
+
+
+def analyze_document(
+    ctx: Context,
+    index_name: str,
+    doc: dict[str, Any],
+) -> dict[str, Any]:
+    """Test how a document would be indexed against an FTS index.
+
+    Sends the ``doc`` JSON to ``/api/analyzeDoc/{index_name}`` and returns
+    the FTS service's analyzer output (tokenization, byte offsets, field
+    routing). No document is stored; this is a diagnostic tool for tuning
+    index mappings and analyzer configuration.
+
+    Read-only in that it doesn't mutate the index. Loaded in the read-only
+    category so users can verify index behavior without needing
+    admin-write-mode.
+    """
+    assert_fts_index_name(index_name)
+    if not isinstance(doc, dict):
+        raise ValueError(f"doc must be a dict (JSON object), got {type(doc).__name__}")
+    settings = get_settings(ctx)
+    return analyze_doc_rest(
+        connection_string=settings["connection_string"],
+        username=settings["username"],
+        password=settings["password"],
+        index_name=index_name,
+        doc=doc,
+        ca_cert_path=settings.get("ca_cert_path"),
+    )
+
+
+# --------------------------------------------------------------------------
+# Write tools (ADMIN_WRITE_TOOLS)
+# --------------------------------------------------------------------------
+
+
+def create_fts_index(
+    ctx: Context,
+    index_name: str,
+    definition: dict[str, Any],
+) -> dict[str, Any]:
+    """Create a new FTS index.
+
+    ``definition`` is a JSON object matching Couchbase's FTS index-definition
+    schema: ``type``, ``name``, ``sourceType``, ``sourceName``, ``params``
+    (with ``mapping``, ``store``, ``doc_config``), ``planParams``. The
+    ``name`` field inside ``definition`` should match ``index_name``; if
+    it doesn't, the tool sets it to ``index_name`` for consistency.
+
+    Fails with a 400 (surfaced as ``RuntimeError``) if the index already
+    exists — use ``update_fts_index`` to modify an existing one.
+
+    Returns a dict with the executed definition and the FTS service response.
+    """
+    _require_write_scope()
+    assert_fts_index_name(index_name)
+
+    if not isinstance(definition, dict):
+        raise ValueError(f"definition must be a dict, got {type(definition).__name__}")
+    # Normalize: force the definition's name to match the URL segment.
+    body = dict(definition)
+    body["name"] = index_name
+
+    logger.info(f"Creating FTS index {index_name!r}")
+    settings = get_settings(ctx)
+    result = create_or_update_fts_index_rest(
+        connection_string=settings["connection_string"],
+        username=settings["username"],
+        password=settings["password"],
+        index_name=index_name,
+        definition=body,
+        ca_cert_path=settings.get("ca_cert_path"),
+    )
+    return {"index_name": index_name, "definition": body, "result": result}
+
+
+def update_fts_index(
+    ctx: Context,
+    index_name: str,
+    definition: dict[str, Any],
+) -> dict[str, Any]:
+    """Update an existing FTS index.
+
+    Uses the same PUT endpoint as ``create_fts_index``; the server accepts
+    updates on existing indexes and applies them in place. If the index
+    does not exist, the server treats this as a create.
+
+    Callers who want strict update-only semantics can call
+    ``get_fts_index`` first to verify existence; enforcing it client-side
+    would race the server anyway.
+    """
+    _require_write_scope()
+    assert_fts_index_name(index_name)
+
+    if not isinstance(definition, dict):
+        raise ValueError(f"definition must be a dict, got {type(definition).__name__}")
+    body = dict(definition)
+    body["name"] = index_name
+
+    logger.info(f"Updating FTS index {index_name!r}")
+    settings = get_settings(ctx)
+    result = create_or_update_fts_index_rest(
+        connection_string=settings["connection_string"],
+        username=settings["username"],
+        password=settings["password"],
+        index_name=index_name,
+        definition=body,
+        ca_cert_path=settings.get("ca_cert_path"),
+    )
+    return {"index_name": index_name, "definition": body, "result": result}
+
+
+def delete_fts_index(
+    ctx: Context,
+    index_name: str,
+    confirm: bool = False,
+    confirm_name: str | None = None,
+) -> dict[str, Any]:
+    """Delete an FTS index. Irreversible; drops the index and all its
+    persisted data.
+
+    Requires BOTH:
+
+    - ``confirm=True``
+    - ``confirm_name`` set to the exact index name
+
+    The name-match is a UX guard against fat-finger deletion; combined
+    with the admin-write-mode gate and the OAuth write-scope check,
+    three independent gates precede a delete.
+    """
+    _require_write_scope()
+    assert_fts_index_name(index_name)
+
+    if not confirm:
+        raise ValueError(
+            "delete_fts_index requires confirm=True. This drops the index "
+            "and its persisted data; re-indexing requires a full ingest."
+        )
+    if confirm_name != index_name:
+        raise ValueError(
+            "delete_fts_index requires confirm_name to exactly match "
+            f"index_name ({index_name!r}). This guard against fat-finger "
+            "deletion matches the delete_bucket pattern."
+        )
+
+    logger.warning(f"Deleting FTS index {index_name!r}")
+    settings = get_settings(ctx)
+    result = delete_fts_index_rest(
+        connection_string=settings["connection_string"],
+        username=settings["username"],
+        password=settings["password"],
+        index_name=index_name,
+        ca_cert_path=settings.get("ca_cert_path"),
+    )
+    return {"index_name": index_name, "deleted": True, "result": result}
+
+
+def pause_fts_index_ingest(
+    ctx: Context,
+    index_name: str,
+) -> dict[str, Any]:
+    """Pause ingestion for an FTS index.
+
+    Stops the index from ingesting new source-data mutations. Queries
+    continue to work against previously-ingested data. Reversible via
+    ``resume_fts_index_ingest``.
+    """
+    _require_write_scope()
+    assert_fts_index_name(index_name)
+
+    logger.info(f"Pausing ingest on FTS index {index_name!r}")
+    settings = get_settings(ctx)
+    result = ingest_control_rest(
+        connection_string=settings["connection_string"],
+        username=settings["username"],
+        password=settings["password"],
+        index_name=index_name,
+        op="pause",
+        ca_cert_path=settings.get("ca_cert_path"),
+    )
+    return {"index_name": index_name, "ingest_paused": True, "result": result}
+
+
+def resume_fts_index_ingest(
+    ctx: Context,
+    index_name: str,
+) -> dict[str, Any]:
+    """Resume ingestion for a previously-paused FTS index."""
+    _require_write_scope()
+    assert_fts_index_name(index_name)
+
+    logger.info(f"Resuming ingest on FTS index {index_name!r}")
+    settings = get_settings(ctx)
+    result = ingest_control_rest(
+        connection_string=settings["connection_string"],
+        username=settings["username"],
+        password=settings["password"],
+        index_name=index_name,
+        op="resume",
+        ca_cert_path=settings.get("ca_cert_path"),
+    )
+    return {"index_name": index_name, "ingest_resumed": True, "result": result}
+
+
+def set_fts_index_query_control(
+    ctx: Context,
+    index_name: str,
+    allow: bool,
+) -> dict[str, Any]:
+    """Allow or disallow queries against an FTS index.
+
+    When ``allow=True`` the index accepts queries; when ``False`` the FTS
+    service rejects queries against the index (useful during maintenance
+    windows or when data is being reloaded and query results would be
+    inconsistent).
+
+    Independent of ingest control: an index can be ingesting but not
+    accepting queries, or vice versa.
+    """
+    _require_write_scope()
+    assert_fts_index_name(index_name)
+
+    op = "allow" if allow else "disallow"
+    logger.info(f"Setting queryControl={op} on FTS index {index_name!r}")
+    settings = get_settings(ctx)
+    result = query_control_rest(
+        connection_string=settings["connection_string"],
+        username=settings["username"],
+        password=settings["password"],
+        index_name=index_name,
+        op=op,
+        ca_cert_path=settings.get("ca_cert_path"),
+    )
+    return {"index_name": index_name, "queries_allowed": allow, "result": result}

--- a/src/cb_mcp/tools/index_admin.py
+++ b/src/cb_mcp/tools/index_admin.py
@@ -1,0 +1,328 @@
+"""
+Tools for index management (DDL).
+
+These tools create, drop, and build GSI indexes and read/update Index
+Service settings. They complement the read-only ``index.py`` tools
+(``list_indexes`` and ``get_index_advisor_recommendations``): the advisor
+recommends indexes, ``list_indexes`` shows them, and these tools act on
+them.
+
+Write gating
+------------
+Index DDL mutates cluster structure. These tools are loaded only when the
+server is *not* in read-only mode AND admin-write mode is enabled (see
+``tools/__init__.py`` ``get_tools`` and ``ADMIN_WRITE_TOOLS``). When an
+OAuth token is present, the caller must additionally hold the write scope;
+this mirrors the scope enforcement in ``run_sql_plus_plus_query`` so a
+read-scoped token cannot mutate indexes even when admin-write mode is on.
+
+DDL is executed through ``run_cluster_query`` rather than
+``run_sql_plus_plus_query``. The latter classifies ``CREATE``/``DROP``/
+``BUILD INDEX`` as structure modifications and blocks them under read-only
+mode; routing DDL through the cluster path keeps load-time gating
+(``ADMIN_WRITE_TOOLS`` + admin-write mode + scope) as the single, explicit
+enforcement point instead of double-gating.
+
+License: MIT - Copyright (c) 2026 Chris Ahrendt
+"""
+
+import logging
+from typing import Any
+
+from fastmcp import Context
+from fastmcp.server.dependencies import get_access_token
+
+from ..utils.config import get_settings
+from ..utils.constants import MCP_SERVER_NAME, SCOPE_WRITE
+from ..utils.index_ddl import (
+    assert_index_create_ddl,
+    assert_index_drop_ddl,
+    safe_ident,
+)
+from ..utils.index_settings import get_gsi_settings, set_gsi_settings
+from .query import run_cluster_query
+
+logger = logging.getLogger(f"{MCP_SERVER_NAME}.tools.index_admin")
+
+
+def _require_write_scope() -> None:
+    """Raise ``PermissionError`` if a token is present but lacks the write scope.
+
+    No-op when no token is in context (stdio transport or OAuth disabled),
+    matching the behavior of ``run_sql_plus_plus_query`` so the same tool
+    body serves authenticated HTTP and unauthenticated stdio without
+    branching at registration time.
+    """
+    token = get_access_token()
+    if token is not None and SCOPE_WRITE not in (token.scopes or []):
+        held = sorted(set(token.scopes or []))
+        msg = f"Index DDL requires the '{SCOPE_WRITE}' scope; token scopes are {held}."
+        logger.warning(msg)
+        raise PermissionError(msg)
+
+
+def create_index(
+    ctx: Context,
+    statement: str | None = None,
+    index_name: str | None = None,
+    bucket_name: str | None = None,
+    scope_name: str | None = None,
+    collection_name: str | None = None,
+    fields: list[str] | None = None,
+    is_primary: bool = False,
+    num_replica: int | None = None,
+    defer_build: bool = False,
+) -> dict[str, Any]:
+    """Create a GSI index.
+
+    Two ways to call this:
+
+    - Raw ``statement``: pass a full SQL++ index-create statement. Only
+      CREATE INDEX / CREATE PRIMARY INDEX / BUILD INDEX / CREATE
+      [HYPERSCALE|COMPOSITE] VECTOR INDEX are accepted; any other SQL++ is
+      rejected.
+    - Structured fields: provide ``bucket_name`` (and optionally
+      ``scope_name`` / ``collection_name``, defaulting to ``_default``) with
+      either ``is_primary=True`` or an ``index_name`` plus ``fields``.
+      Optional ``num_replica`` and ``defer_build`` become a WITH clause.
+
+    Returns a dict with the executed statement and result rows.
+    """
+    _require_write_scope()
+
+    if statement:
+        invalid = assert_index_create_ddl(statement)
+        if invalid:
+            raise ValueError(invalid)
+        stmt = statement
+    else:
+        if not bucket_name:
+            raise ValueError("bucket_name is required when statement is not provided")
+        bucket = safe_ident(bucket_name)
+        scope = safe_ident(scope_name or "_default")
+        coll = safe_ident(collection_name or "_default")
+
+        if is_primary:
+            idx = safe_ident(index_name) if index_name else ""
+            target = f"{idx} " if idx else ""
+            stmt = f"CREATE PRIMARY INDEX {target}ON {bucket}.{scope}.{coll}"
+        else:
+            if not index_name:
+                raise ValueError("index_name is required for non-primary indexes")
+            if not fields:
+                raise ValueError("fields are required for non-primary indexes")
+            idx = safe_ident(index_name)
+            field_list = ", ".join(safe_ident(f) for f in fields)
+            stmt = f"CREATE INDEX {idx} ON {bucket}.{scope}.{coll} ({field_list})"
+
+        withs = []
+        if num_replica is not None:
+            withs.append(f'"num_replica": {int(num_replica)}')
+        if defer_build:
+            withs.append('"defer_build": true')
+        if withs:
+            stmt += " WITH {" + ", ".join(withs) + "}"
+
+    logger.info("Executing index create")
+    rows = run_cluster_query(ctx, stmt)
+    return {"statement": stmt, "results": rows}
+
+
+def drop_index(
+    ctx: Context,
+    statement: str | None = None,
+    index_name: str | None = None,
+    bucket_name: str | None = None,
+    scope_name: str | None = None,
+    collection_name: str | None = None,
+    is_primary: bool = False,
+) -> dict[str, Any]:
+    """Drop a GSI index.
+
+    Two ways to call this:
+
+    - Raw ``statement``: a full DROP INDEX / DROP PRIMARY INDEX / DROP VECTOR
+      INDEX statement. Any other SQL++ is rejected.
+    - Structured fields: ``bucket_name`` (and optional ``scope_name`` /
+      ``collection_name``) with either ``is_primary=True`` or ``index_name``.
+
+    Returns a dict with the executed statement and result rows.
+    """
+    _require_write_scope()
+
+    if statement:
+        invalid = assert_index_drop_ddl(statement)
+        if invalid:
+            raise ValueError(invalid)
+        stmt = statement
+    else:
+        if not bucket_name:
+            raise ValueError("bucket_name is required when statement is not provided")
+        bucket = safe_ident(bucket_name)
+        scope = safe_ident(scope_name or "_default")
+        coll = safe_ident(collection_name or "_default")
+
+        if is_primary:
+            stmt = f"DROP PRIMARY INDEX ON {bucket}.{scope}.{coll}"
+        else:
+            if not index_name:
+                raise ValueError("index_name is required for non-primary drop")
+            idx = safe_ident(index_name)
+            stmt = f"DROP INDEX {idx} ON {bucket}.{scope}.{coll}"
+
+    logger.info("Executing index drop")
+    rows = run_cluster_query(ctx, stmt)
+    return {"statement": stmt, "results": rows}
+
+
+def build_deferred_indexes(
+    ctx: Context,
+    bucket_name: str,
+    index_names: list[str],
+    scope_name: str | None = None,
+    collection_name: str | None = None,
+) -> dict[str, Any]:
+    """Build one or more deferred GSI indexes.
+
+    ``bucket_name`` and ``index_names`` are required. Provide both
+    ``scope_name`` and ``collection_name`` to build within a specific
+    collection (Couchbase 7+); omit both for a bucket-level build.
+
+    Returns a dict with the executed statement and result rows.
+    """
+    _require_write_scope()
+
+    if not index_names:
+        raise ValueError("index_names must contain at least one index name")
+
+    bucket = safe_ident(bucket_name)
+    if scope_name and collection_name:
+        keyspace = f"{bucket}.{safe_ident(scope_name)}.{safe_ident(collection_name)}"
+    elif scope_name or collection_name:
+        raise ValueError("scope_name and collection_name must be provided together")
+    else:
+        keyspace = bucket
+
+    names = ", ".join(safe_ident(n) for n in index_names)
+    stmt = f"BUILD INDEX ON {keyspace} ({names})"
+
+    logger.info("Executing deferred index build")
+    rows = run_cluster_query(ctx, stmt)
+    return {"statement": stmt, "results": rows}
+
+
+# --------------------------------------------------------------------------
+# GSI settings (cluster-manager /settings/indexes, port 8091/18091)
+# --------------------------------------------------------------------------
+
+# Named GSI settings exposed as explicit tool parameters. Maps the tool's
+# snake_case argument to the endpoint's camelCase form key. These are the
+# complete set of keys documented for POST /settings/indexes (Couchbase Server
+# 8.0). Verified against docs 2026-07-02.
+_GSI_SETTING_KEYS: dict[str, str] = {
+    "indexer_threads": "indexerThreads",
+    "log_level": "logLevel",
+    "max_rollback_points": "maxRollbackPoints",
+    "storage_mode": "storageMode",
+    "num_replica": "numReplica",
+    "redistribute_indexes": "redistributeIndexes",
+    "enable_page_bloom_filter": "enablePageBloomFilter",
+    "enable_shard_affinity": "enableShardAffinity",
+    "memory_snapshot_interval": "memorySnapshotInterval",
+    "stable_snapshot_interval": "stableSnapshotInterval",
+}
+
+# Allow-list of accepted camelCase form keys for the ``extra`` escape hatch.
+# The named parameters already cover the full documented key set; ``extra``
+# exists for forward-compatibility if a future server version adds a key. It
+# is validated against this allow-list so it cannot be used to POST arbitrary
+# keys to /settings/indexes. When Couchbase documents a new GSI setting, add
+# its camelCase key here (and, ideally, a named parameter above).
+_VALID_GSI_FORM_KEYS: frozenset[str] = frozenset(_GSI_SETTING_KEYS.values())
+
+
+def admin_index_settings_get(ctx: Context) -> dict[str, Any]:
+    """Get the cluster's Global Secondary Index (GSI) settings.
+
+    Reads the GSI settings from the cluster manager (/settings/indexes).
+    Returns the settings as a dict, e.g. indexerThreads, logLevel,
+    maxRollbackPoints, storageMode, numReplica, redistributeIndexes.
+    Read-only.
+    """
+    settings = get_settings(ctx)
+    return get_gsi_settings(
+        connection_string=settings["connection_string"],
+        username=settings["username"],
+        password=settings["password"],
+        ca_cert_path=settings.get("ca_cert_path"),
+    )
+
+
+def admin_index_settings_set(
+    ctx: Context,
+    indexer_threads: int | None = None,
+    log_level: str | None = None,
+    max_rollback_points: int | None = None,
+    storage_mode: str | None = None,
+    num_replica: int | None = None,
+    redistribute_indexes: bool | None = None,
+    enable_page_bloom_filter: bool | None = None,
+    enable_shard_affinity: bool | None = None,
+    memory_snapshot_interval: int | None = None,
+    stable_snapshot_interval: int | None = None,
+    extra: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Update the cluster's Global Secondary Index (GSI) settings.
+
+    Provide any subset of the named parameters; only supplied values are
+    sent, and unspecified settings are left unchanged by the server. Use
+    ``extra`` to pass settings not covered by the named parameters (keys must
+    be documented GSI setting camelCase names; unknown keys are rejected).
+    Returns the resulting settings after the update.
+
+    Note: Couchbase advises changing most GSI settings only when directed by
+    Couchbase Support. This tool loads only when read-only mode is off and
+    admin-write mode is on, and (when OAuth is active) requires the write
+    scope.
+    """
+    _require_write_scope()
+
+    named = {
+        "indexer_threads": indexer_threads,
+        "log_level": log_level,
+        "max_rollback_points": max_rollback_points,
+        "storage_mode": storage_mode,
+        "num_replica": num_replica,
+        "redistribute_indexes": redistribute_indexes,
+        "enable_page_bloom_filter": enable_page_bloom_filter,
+        "enable_shard_affinity": enable_shard_affinity,
+        "memory_snapshot_interval": memory_snapshot_interval,
+        "stable_snapshot_interval": stable_snapshot_interval,
+    }
+    params: dict[str, Any] = {
+        _GSI_SETTING_KEYS[k]: v for k, v in named.items() if v is not None
+    }
+    if extra:
+        unknown = sorted(set(extra) - _VALID_GSI_FORM_KEYS)
+        if unknown:
+            raise ValueError(
+                f"Unknown GSI setting key(s) in 'extra': {unknown}. Allowed "
+                f"keys are {sorted(_VALID_GSI_FORM_KEYS)}. Use a named "
+                "parameter where one exists."
+            )
+        params.update(extra)
+
+    if not params:
+        raise ValueError(
+            "Provide at least one setting to update (a named parameter or "
+            "an 'extra' entry)."
+        )
+
+    settings = get_settings(ctx)
+    return set_gsi_settings(
+        connection_string=settings["connection_string"],
+        username=settings["username"],
+        password=settings["password"],
+        params=params,
+        ca_cert_path=settings.get("ca_cert_path"),
+    )

--- a/src/cb_mcp/tools/xdcr_admin.py
+++ b/src/cb_mcp/tools/xdcr_admin.py
@@ -1,0 +1,581 @@
+"""
+Tools for XDCR (Cross-Datacenter Replication) administration.
+
+XDCR is split between two concepts:
+
+- **Remote clusters**: named references to peer Couchbase clusters
+  (create/list/update/delete). A remote-cluster reference is a stored
+  hostname + credentials pair.
+- **Replications**: bucket-to-bucket (or bucket-to-collection) streams
+  that use a remote cluster as a target. Replications have lifecycle
+  (create, pause, resume, delete) and per-replication settings
+  (throttling, filter expressions, priority, compression).
+
+Write gating
+------------
+XDCR admin mutates cross-cluster infrastructure. These tools are loaded
+only when the server is *not* in read-only mode AND admin-write mode is
+enabled (see ``tools/__init__.py`` ``get_tools`` and
+``ADMIN_WRITE_TOOLS``). When an OAuth token is present, the caller must
+additionally hold the write scope; this mirrors the scope enforcement in
+``index_admin.py``, ``bucket_admin.py``, and ``collections_admin.py``.
+
+Delete confirmation
+-------------------
+``delete_remote_cluster`` and ``delete_replication`` both require BOTH
+``confirm=True`` AND a ``confirm_name`` matching the target's identifier.
+This mirrors the pattern established by ``delete_bucket`` in the bucket
+admin module; combined with admin-write-mode gating and the write-scope
+check, three independent gates precede a destructive XDCR operation.
+
+License: MIT - Copyright (c) 2026 Chris Ahrendt
+"""
+
+import logging
+from typing import Any
+
+from fastmcp import Context
+from fastmcp.server.dependencies import get_access_token
+
+from ..utils.config import get_settings
+from ..utils.constants import MCP_SERVER_NAME, SCOPE_WRITE
+from ..utils.xdcr_rest import (
+    assert_remote_cluster_name,
+    assert_replication_id,
+    create_remote_cluster_rest,
+    create_replication_rest,
+    delete_remote_cluster_rest,
+    delete_replication_rest,
+    get_replication_settings_rest,
+    list_remote_clusters_rest,
+    list_replications_rest,
+    update_remote_cluster_rest,
+    update_replication_settings_rest,
+)
+
+logger = logging.getLogger(f"{MCP_SERVER_NAME}.tools.xdcr_admin")
+
+
+def _require_write_scope() -> None:
+    """Raise ``PermissionError`` if a token is present but lacks the write scope."""
+    token = get_access_token()
+    if token is not None and SCOPE_WRITE not in (token.scopes or []):
+        held = sorted(set(token.scopes or []))
+        msg = f"XDCR admin requires the '{SCOPE_WRITE}' scope; token scopes are {held}."
+        logger.warning(msg)
+        raise PermissionError(msg)
+
+
+# --------------------------------------------------------------------------
+# Parameter key maps (snake_case → camelCase form keys per Couchbase docs)
+# --------------------------------------------------------------------------
+
+_REMOTE_CLUSTER_KEYS: dict[str, str] = {
+    "hostname": "hostname",
+    "username": "username",
+    "password": "password",
+    "demand_encryption": "demandEncryption",
+    "encryption_type": "encryptionType",  # full | half (deprecated) | none
+    "certificate": "certificate",
+    "client_certificate": "clientCertificate",
+    "client_key": "clientKey",
+    "network_type": "network_type",
+}
+_VALID_REMOTE_CLUSTER_KEYS: frozenset[str] = frozenset(_REMOTE_CLUSTER_KEYS.values())
+
+
+# createReplication accepts a different key set than settings-update.
+# Both share ``pauseRequested`` and the "delivery" tuning keys.
+_CREATE_REPLICATION_KEYS: dict[str, str] = {
+    "from_bucket": "fromBucket",
+    "to_cluster": "toCluster",
+    "to_bucket": "toBucket",
+    "replication_type": "replicationType",  # continuous | one-time
+    "filter_expression": "filterExpression",
+    "priority": "priority",  # High | Medium | Low
+    "compression_type": "compressionType",  # None | Auto | Snappy
+    "network_type": "networkType",
+}
+_VALID_CREATE_REPLICATION_KEYS: frozenset[str] = frozenset(
+    _CREATE_REPLICATION_KEYS.values()
+)
+
+
+_REPLICATION_SETTINGS_KEYS: dict[str, str] = {
+    "pause_requested": "pauseRequested",
+    "priority": "priority",
+    "compression_type": "compressionType",
+    "filter_expression": "filterExpression",
+    "filter_skip_restream": "filterSkipRestream",
+    "checkpoint_interval": "checkpointInterval",
+    "worker_batch_size": "workerBatchSize",
+    "doc_batch_size_kb": "docBatchSizeKb",
+    "failure_restart_interval": "failureRestartInterval",
+    "source_nozzle_per_node": "sourceNozzlePerNode",
+    "target_nozzle_per_node": "targetNozzlePerNode",
+    "log_level": "logLevel",
+    "stats_interval": "statsInterval",
+    "network_type": "networkType",
+    "collections_mapping_rules": "collectionsMappingRules",  # JSON
+    "collections_migration_mode": "collectionsMigrationMode",
+    "collections_mirroring_mode": "collectionsMirroringMode",
+    "collections_explicit_mapping": "collectionsExplicitMapping",
+    "collections_oso_mode": "collectionsOSOMode",
+}
+_VALID_REPLICATION_SETTINGS_KEYS: frozenset[str] = frozenset(
+    _REPLICATION_SETTINGS_KEYS.values()
+)
+
+
+def _collect(
+    keymap: dict[str, str],
+    allowed: frozenset[str],
+    named: dict[str, Any],
+    extra: dict[str, Any] | None,
+) -> dict[str, Any]:
+    """Merge named args and extras into a form-body dict.
+
+    Rejects unknown ``extra`` keys against ``allowed``.
+    """
+    form: dict[str, Any] = {keymap[k]: v for k, v in named.items() if v is not None}
+    if extra:
+        unknown = sorted(set(extra) - allowed)
+        if unknown:
+            raise ValueError(
+                f"Unknown XDCR setting key(s) in 'extra': {unknown}. "
+                f"Allowed keys are {sorted(allowed)}. Use a named parameter "
+                "where one exists."
+            )
+        form.update(extra)
+    return form
+
+
+# --------------------------------------------------------------------------
+# Remote-cluster tools
+# --------------------------------------------------------------------------
+
+
+def create_remote_cluster(
+    ctx: Context,
+    name: str,
+    hostname: str,
+    username: str,
+    password: str,
+    demand_encryption: bool | None = None,
+    encryption_type: str | None = None,
+    certificate: str | None = None,
+    client_certificate: str | None = None,
+    client_key: str | None = None,
+    network_type: str | None = None,
+    extra: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Create a remote-cluster reference.
+
+    Required: ``name`` (unique reference name), ``hostname`` (target
+    cluster's connection string, e.g. ``couchbases://target.example.com``),
+    ``username`` and ``password`` (credentials on the target cluster).
+
+    Optional TLS-related fields (``demand_encryption``, ``encryption_type``,
+    ``certificate``, ``client_certificate``, ``client_key``) are required
+    when the target cluster requires TLS.
+
+    Returns a dict with the form body sent and the cluster response.
+    """
+    _require_write_scope()
+    assert_remote_cluster_name(name)
+
+    named = {
+        "hostname": hostname,
+        "username": username,
+        "password": password,
+        "demand_encryption": demand_encryption,
+        "encryption_type": encryption_type,
+        "certificate": certificate,
+        "client_certificate": client_certificate,
+        "client_key": client_key,
+        "network_type": network_type,
+    }
+    form = {"name": name}
+    form.update(
+        _collect(_REMOTE_CLUSTER_KEYS, _VALID_REMOTE_CLUSTER_KEYS, named, extra)
+    )
+
+    logger.info(f"Creating remote cluster {name!r}")
+    settings = get_settings(ctx)
+    result = create_remote_cluster_rest(
+        connection_string=settings["connection_string"],
+        username=settings["username"],
+        password=settings["password"],
+        form=form,
+        ca_cert_path=settings.get("ca_cert_path"),
+    )
+    return {"name": name, "body": form, "result": result}
+
+
+def update_remote_cluster(
+    ctx: Context,
+    name: str,
+    hostname: str | None = None,
+    username: str | None = None,
+    password: str | None = None,
+    demand_encryption: bool | None = None,
+    encryption_type: str | None = None,
+    certificate: str | None = None,
+    client_certificate: str | None = None,
+    client_key: str | None = None,
+    network_type: str | None = None,
+    extra: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Update an existing remote-cluster reference.
+
+    Only the supplied fields are sent; unspecified ones stay unchanged.
+    At least one updatable field must be provided.
+    """
+    _require_write_scope()
+    assert_remote_cluster_name(name)
+
+    named = {
+        "hostname": hostname,
+        "username": username,
+        "password": password,
+        "demand_encryption": demand_encryption,
+        "encryption_type": encryption_type,
+        "certificate": certificate,
+        "client_certificate": client_certificate,
+        "client_key": client_key,
+        "network_type": network_type,
+    }
+    form = _collect(_REMOTE_CLUSTER_KEYS, _VALID_REMOTE_CLUSTER_KEYS, named, extra)
+    if not form:
+        raise ValueError(
+            "Provide at least one field to update (a named parameter or "
+            "an 'extra' entry)."
+        )
+
+    logger.info(f"Updating remote cluster {name!r}")
+    settings = get_settings(ctx)
+    result = update_remote_cluster_rest(
+        connection_string=settings["connection_string"],
+        username=settings["username"],
+        password=settings["password"],
+        name=name,
+        form=form,
+        ca_cert_path=settings.get("ca_cert_path"),
+    )
+    return {"name": name, "body": form, "result": result}
+
+
+def delete_remote_cluster(
+    ctx: Context,
+    name: str,
+    confirm: bool = False,
+    confirm_name: str | None = None,
+) -> dict[str, Any]:
+    """Delete a remote-cluster reference. Requires ``confirm=True`` AND
+    ``confirm_name`` matching the target reference name.
+
+    Fails if any replication currently uses this remote cluster (Couchbase
+    rejects deletion in that case).
+    """
+    _require_write_scope()
+    assert_remote_cluster_name(name)
+
+    if not confirm:
+        raise ValueError(
+            "delete_remote_cluster requires confirm=True. This removes the "
+            "cross-cluster connection and any replications pointing at it."
+        )
+    if confirm_name != name:
+        raise ValueError(
+            "delete_remote_cluster requires confirm_name to exactly match "
+            f"name ({name!r}). This guard against fat-finger deletion "
+            "matches the delete_bucket pattern."
+        )
+
+    logger.warning(f"Deleting remote cluster {name!r}")
+    settings = get_settings(ctx)
+    result = delete_remote_cluster_rest(
+        connection_string=settings["connection_string"],
+        username=settings["username"],
+        password=settings["password"],
+        name=name,
+        ca_cert_path=settings.get("ca_cert_path"),
+    )
+    return {"name": name, "deleted": True, "result": result}
+
+
+def list_remote_clusters(ctx: Context) -> dict[str, Any]:
+    """List all remote-cluster references on this cluster.
+
+    Returns a dict with the ``remote_clusters`` key holding the array of
+    reference records returned by the cluster manager.
+    """
+    settings = get_settings(ctx)
+    result = list_remote_clusters_rest(
+        connection_string=settings["connection_string"],
+        username=settings["username"],
+        password=settings["password"],
+        ca_cert_path=settings.get("ca_cert_path"),
+    )
+    return {"remote_clusters": result}
+
+
+# --------------------------------------------------------------------------
+# Replication lifecycle tools
+# --------------------------------------------------------------------------
+
+
+def create_replication(
+    ctx: Context,
+    from_bucket: str,
+    to_cluster: str,
+    to_bucket: str,
+    replication_type: str = "continuous",
+    filter_expression: str | None = None,
+    priority: str | None = None,
+    compression_type: str | None = None,
+    network_type: str | None = None,
+    extra: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Create a replication from ``from_bucket`` on this cluster to
+    ``to_bucket`` on the named remote cluster (``to_cluster``).
+
+    ``replication_type`` is ``"continuous"`` (default) or ``"one-time"``.
+
+    Returns a dict with the body sent, the resulting replication ID from
+    the server response, and the raw result.
+    """
+    _require_write_scope()
+
+    if replication_type not in ("continuous", "one-time"):
+        raise ValueError(
+            f"replication_type must be 'continuous' or 'one-time', got "
+            f"{replication_type!r}"
+        )
+
+    named = {
+        "from_bucket": from_bucket,
+        "to_cluster": to_cluster,
+        "to_bucket": to_bucket,
+        "replication_type": replication_type,
+        "filter_expression": filter_expression,
+        "priority": priority,
+        "compression_type": compression_type,
+        "network_type": network_type,
+    }
+    form = _collect(
+        _CREATE_REPLICATION_KEYS, _VALID_CREATE_REPLICATION_KEYS, named, extra
+    )
+
+    logger.info(
+        f"Creating XDCR: {from_bucket} -> {to_cluster}/{to_bucket} ({replication_type})"
+    )
+    settings = get_settings(ctx)
+    result = create_replication_rest(
+        connection_string=settings["connection_string"],
+        username=settings["username"],
+        password=settings["password"],
+        form=form,
+        ca_cert_path=settings.get("ca_cert_path"),
+    )
+    replication_id = result.get("id") if isinstance(result, dict) else None
+    return {"body": form, "replication_id": replication_id, "result": result}
+
+
+def delete_replication(
+    ctx: Context,
+    replication_id: str,
+    confirm: bool = False,
+    confirm_name: str | None = None,
+) -> dict[str, Any]:
+    """Cancel (delete) an active replication. Requires ``confirm=True`` AND
+    ``confirm_name`` matching the replication ID exactly.
+    """
+    _require_write_scope()
+    assert_replication_id(replication_id)
+
+    if not confirm:
+        raise ValueError(
+            "delete_replication requires confirm=True. This cancels the "
+            "replication and stops all data movement to the target."
+        )
+    if confirm_name != replication_id:
+        raise ValueError(
+            "delete_replication requires confirm_name to exactly match "
+            f"replication_id ({replication_id!r}). This guard against "
+            "fat-finger deletion matches the delete_bucket pattern."
+        )
+
+    logger.warning(f"Deleting replication {replication_id!r}")
+    settings = get_settings(ctx)
+    result = delete_replication_rest(
+        connection_string=settings["connection_string"],
+        username=settings["username"],
+        password=settings["password"],
+        replication_id=replication_id,
+        ca_cert_path=settings.get("ca_cert_path"),
+    )
+    return {"replication_id": replication_id, "deleted": True, "result": result}
+
+
+def pause_replication(
+    ctx: Context,
+    replication_id: str,
+) -> dict[str, Any]:
+    """Pause a running replication (sets ``pauseRequested=true``).
+
+    Reversible via ``resume_replication``. Data movement stops but the
+    replication configuration and checkpoint state are preserved.
+    """
+    _require_write_scope()
+    assert_replication_id(replication_id)
+
+    logger.info(f"Pausing replication {replication_id!r}")
+    settings = get_settings(ctx)
+    result = update_replication_settings_rest(
+        connection_string=settings["connection_string"],
+        username=settings["username"],
+        password=settings["password"],
+        replication_id=replication_id,
+        form={"pauseRequested": True},
+        ca_cert_path=settings.get("ca_cert_path"),
+    )
+    return {"replication_id": replication_id, "paused": True, "result": result}
+
+
+def resume_replication(
+    ctx: Context,
+    replication_id: str,
+) -> dict[str, Any]:
+    """Resume a paused replication (sets ``pauseRequested=false``)."""
+    _require_write_scope()
+    assert_replication_id(replication_id)
+
+    logger.info(f"Resuming replication {replication_id!r}")
+    settings = get_settings(ctx)
+    result = update_replication_settings_rest(
+        connection_string=settings["connection_string"],
+        username=settings["username"],
+        password=settings["password"],
+        replication_id=replication_id,
+        form={"pauseRequested": False},
+        ca_cert_path=settings.get("ca_cert_path"),
+    )
+    return {"replication_id": replication_id, "resumed": True, "result": result}
+
+
+def list_replications(ctx: Context) -> dict[str, Any]:
+    """List all XDCR replications on this cluster.
+
+    Reads ``/pools/default/tasks`` and filters to XDCR tasks. Returns a
+    dict with the ``replications`` key.
+    """
+    settings = get_settings(ctx)
+    result = list_replications_rest(
+        connection_string=settings["connection_string"],
+        username=settings["username"],
+        password=settings["password"],
+        ca_cert_path=settings.get("ca_cert_path"),
+    )
+    return {"replications": result}
+
+
+def get_replication_settings(
+    ctx: Context,
+    replication_id: str,
+) -> dict[str, Any]:
+    """Get the current settings for a replication.
+
+    Returns the raw settings dict from ``GET /settings/replications/{id}``.
+    Includes throttling, filter expressions, priority, and pause state.
+    """
+    assert_replication_id(replication_id)
+    settings = get_settings(ctx)
+    return get_replication_settings_rest(
+        connection_string=settings["connection_string"],
+        username=settings["username"],
+        password=settings["password"],
+        replication_id=replication_id,
+        ca_cert_path=settings.get("ca_cert_path"),
+    )
+
+
+def update_replication_settings(
+    ctx: Context,
+    replication_id: str,
+    pause_requested: bool | None = None,
+    priority: str | None = None,
+    compression_type: str | None = None,
+    filter_expression: str | None = None,
+    filter_skip_restream: bool | None = None,
+    checkpoint_interval: int | None = None,
+    worker_batch_size: int | None = None,
+    doc_batch_size_kb: int | None = None,
+    failure_restart_interval: int | None = None,
+    source_nozzle_per_node: int | None = None,
+    target_nozzle_per_node: int | None = None,
+    log_level: str | None = None,
+    stats_interval: int | None = None,
+    network_type: str | None = None,
+    collections_mapping_rules: dict[str, Any] | None = None,
+    collections_migration_mode: bool | None = None,
+    collections_mirroring_mode: bool | None = None,
+    collections_explicit_mapping: bool | None = None,
+    collections_oso_mode: bool | None = None,
+    extra: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Update a subset of a replication's settings.
+
+    Only the fields supplied are sent to the server. At least one setting
+    must be provided. Prefer the named parameters; ``extra`` exists for
+    forward compatibility with settings not yet exposed here.
+
+    Returns a dict with the body sent and the server response.
+    """
+    _require_write_scope()
+    assert_replication_id(replication_id)
+
+    named = {
+        "pause_requested": pause_requested,
+        "priority": priority,
+        "compression_type": compression_type,
+        "filter_expression": filter_expression,
+        "filter_skip_restream": filter_skip_restream,
+        "checkpoint_interval": checkpoint_interval,
+        "worker_batch_size": worker_batch_size,
+        "doc_batch_size_kb": doc_batch_size_kb,
+        "failure_restart_interval": failure_restart_interval,
+        "source_nozzle_per_node": source_nozzle_per_node,
+        "target_nozzle_per_node": target_nozzle_per_node,
+        "log_level": log_level,
+        "stats_interval": stats_interval,
+        "network_type": network_type,
+        "collections_mapping_rules": collections_mapping_rules,
+        "collections_migration_mode": collections_migration_mode,
+        "collections_mirroring_mode": collections_mirroring_mode,
+        "collections_explicit_mapping": collections_explicit_mapping,
+        "collections_oso_mode": collections_oso_mode,
+    }
+    form = _collect(
+        _REPLICATION_SETTINGS_KEYS,
+        _VALID_REPLICATION_SETTINGS_KEYS,
+        named,
+        extra,
+    )
+    if not form:
+        raise ValueError(
+            "Provide at least one setting to update (a named parameter or "
+            "an 'extra' entry)."
+        )
+
+    logger.info(f"Updating replication settings for {replication_id!r}")
+    settings = get_settings(ctx)
+    result = update_replication_settings_rest(
+        connection_string=settings["connection_string"],
+        username=settings["username"],
+        password=settings["password"],
+        replication_id=replication_id,
+        form=form,
+        ca_cert_path=settings.get("ca_cert_path"),
+    )
+    return {"replication_id": replication_id, "body": form, "result": result}

--- a/src/cb_mcp/utils/diagnostics_rest.py
+++ b/src/cb_mcp/utils/diagnostics_rest.py
@@ -1,0 +1,346 @@
+"""
+REST client for cluster diagnostics and stats endpoints.
+
+Reads across every major subsystem:
+
+- ``/pools/default`` — cluster info, nodes, quotas, storage totals.
+- ``/pools/default/buckets/{bucket}/stats`` — per-bucket runtime stats
+  (ops per second, disk queues, memory).
+- ``/pools/default/buckets/{bucket}/stats/curr_items`` and similar — KV
+  stats (per-bucket, no bucket filter possible without one).
+- ``/pools/default/tasks`` — rebalance / xdcr / compaction tasks (used by
+  chunk 4; not re-exposed here).
+- ``/nodes/self`` — the node the connection currently lands on.
+- ``/settings/querySettings`` and ``/admin/settings`` — query and index
+  service settings (settings-shaped stats).
+- ``/api/nsstats`` (FTS, port 8094/18094) — search service stats.
+- ``/settings/logRedaction`` (paired) plus ``/diag/eval`` gated — server
+  logs are NOT retrievable via a simple REST endpoint; the closest
+  supported surface is ``/logs`` on port 8091 which returns the recent
+  server-log entries. That's the endpoint ``get_error_logs`` uses.
+
+Slow queries: Couchbase Query Service exposes a ``system:completed_requests``
+keyspace queryable via SQL++. Since chunk 1 (``list_indexes`` etc.) shows
+the pattern of running SQL++ through ``run_cluster_query`` to get the
+Query Service's system tables, ``get_slow_queries`` uses the same path.
+
+Bucket-name validation is inlined here rather than imported from
+``bucket_admin_rest`` so this module can be reviewed and merged
+independently of the bucket-management PR. The validator and encoder are
+byte-identical to the ones there; if both PRs land, a future cleanup can
+consolidate them into a shared ``url_utils`` module.
+
+Verified against Couchbase Server docs (rest-api/rest-node-details,
+rest-bucket-stats, cbq-monitoring, ns-stats) 2026-07-06.
+
+License: MIT - Copyright (c) 2026 Chris Ahrendt
+"""
+
+import logging
+import re
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from .constants import MCP_SERVER_NAME
+from .index_utils import (
+    _determine_ssl_verification,
+    _extract_hosts_from_connection_string,
+)
+
+logger = logging.getLogger(f"{MCP_SERVER_NAME}.utils.diagnostics_rest")
+
+# Cluster-manager ports (same as bucket admin and XDCR).
+_MGMT_PORT = 8091
+_MGMT_TLS_PORT = 18091
+
+# FTS service ports (matches fts_rest).
+_FTS_PORT = 8094
+_FTS_TLS_PORT = 18094
+
+# Query service ports (used for reading query settings directly rather
+# than proxied through cluster manager).
+_QUERY_PORT = 8093
+_QUERY_TLS_PORT = 18093
+
+# Bucket name charset per Couchbase docs. Duplicated here from
+# bucket_admin_rest so this module stands alone. See module docstring.
+_BUCKET_NAME_RE = re.compile(r"^[A-Za-z0-9._\-%]{1,100}$")
+
+
+def assert_bucket_name(name: str) -> None:
+    """Reject bucket names that don't match Couchbase's documented charset.
+
+    Duplicated from ``bucket_admin_rest.assert_bucket_name`` so this module
+    can be merged independently. Behavior is intentionally identical.
+    """
+    if not isinstance(name, str) or not _BUCKET_NAME_RE.fullmatch(name):
+        raise ValueError(
+            f"Invalid bucket name {name!r}. Bucket names must be 1-100 chars "
+            "of [A-Za-z0-9._%-]."
+        )
+
+
+def _encode_path_segment(value: str) -> str:
+    """URL-encode a value for use as a REST path segment.
+
+    Same defense-in-depth pattern as the other REST helpers: ``%`` is a
+    valid Couchbase name character, and raw interpolation could produce
+    path-confusion vectors if a name were, e.g., ``%2f%2e%2e``. Encoding
+    with ``safe=""`` produces the double-encoded form the server treats
+    as an opaque identifier.
+    """
+    return quote(value, safe="")
+
+
+def _mgmt_base(connection_string: str) -> tuple[str, int]:
+    """Return (scheme, port) for the cluster-manager endpoint."""
+    is_tls = connection_string.lower().startswith("couchbases://")
+    return ("https", _MGMT_TLS_PORT) if is_tls else ("http", _MGMT_PORT)
+
+
+def _fts_base(connection_string: str) -> tuple[str, int]:
+    """Return (scheme, port) for the FTS service endpoint."""
+    is_tls = connection_string.lower().startswith("couchbases://")
+    return ("https", _FTS_TLS_PORT) if is_tls else ("http", _FTS_PORT)
+
+
+def _query_base(connection_string: str) -> tuple[str, int]:
+    """Return (scheme, port) for the Query service admin endpoint."""
+    is_tls = connection_string.lower().startswith("couchbases://")
+    return ("https", _QUERY_TLS_PORT) if is_tls else ("http", _QUERY_PORT)
+
+
+def _get_json(
+    *,
+    connection_string: str,
+    username: str,
+    password: str,
+    ca_cert_path: str | None,
+    timeout: int,
+    scheme: str,
+    port: int,
+    path: str,
+) -> Any:
+    """Issue a GET, trying each host in the connection string in turn.
+
+    Returns parsed JSON on success; raises ``RuntimeError`` if every host
+    fails. Returns an empty dict when the server returns no body.
+    """
+    hosts = _extract_hosts_from_connection_string(connection_string)
+    verify_ssl = _determine_ssl_verification(connection_string, ca_cert_path)
+
+    last_error: Exception | None = None
+    with httpx.Client(verify=verify_ssl, timeout=timeout) as client:
+        for host in hosts:
+            url = f"{scheme}://{host}:{port}{path}"
+            try:
+                logger.info(f"GET {url}")
+                resp = client.get(url, auth=(username, password))
+                resp.raise_for_status()
+                content_type = resp.headers.get("content-type", "")
+                if resp.content and content_type.startswith("application/json"):
+                    return resp.json()
+                return {}
+            except httpx.HTTPError as e:
+                logger.warning(f"Diagnostics GET failed on {host}: {e}")
+                last_error = e
+
+    error_msg = f"Diagnostics GET {path} failed on all hosts: {hosts}"
+    if last_error:
+        error_msg += f". Last error: {last_error}"
+    logger.error(error_msg)
+    raise RuntimeError(error_msg)
+
+
+# --------------------------------------------------------------------------
+# Public REST wrappers
+# --------------------------------------------------------------------------
+
+
+def get_pools_default_rest(
+    connection_string: str,
+    username: str,
+    password: str,
+    ca_cert_path: str | None = None,
+    timeout: int = 30,
+) -> dict[str, Any]:
+    """GET /pools/default — cluster-wide info: nodes, quotas, storage, tasks."""
+    scheme, port = _mgmt_base(connection_string)
+    return _get_json(
+        connection_string=connection_string,
+        username=username,
+        password=password,
+        ca_cert_path=ca_cert_path,
+        timeout=timeout,
+        scheme=scheme,
+        port=port,
+        path="/pools/default",
+    )
+
+
+def get_node_self_rest(
+    connection_string: str,
+    username: str,
+    password: str,
+    ca_cert_path: str | None = None,
+    timeout: int = 30,
+) -> dict[str, Any]:
+    """GET /nodes/self — info for the node the connection lands on."""
+    scheme, port = _mgmt_base(connection_string)
+    return _get_json(
+        connection_string=connection_string,
+        username=username,
+        password=password,
+        ca_cert_path=ca_cert_path,
+        timeout=timeout,
+        scheme=scheme,
+        port=port,
+        path="/nodes/self",
+    )
+
+
+def get_bucket_stats_rest(
+    connection_string: str,
+    username: str,
+    password: str,
+    bucket_name: str,
+    ca_cert_path: str | None = None,
+    timeout: int = 30,
+) -> dict[str, Any]:
+    """GET /pools/default/buckets/{bucket}/stats — per-bucket runtime stats."""
+    assert_bucket_name(bucket_name)
+    scheme, port = _mgmt_base(connection_string)
+    return _get_json(
+        connection_string=connection_string,
+        username=username,
+        password=password,
+        ca_cert_path=ca_cert_path,
+        timeout=timeout,
+        scheme=scheme,
+        port=port,
+        path=f"/pools/default/buckets/{_encode_path_segment(bucket_name)}/stats",
+    )
+
+
+def get_index_stats_rest(
+    connection_string: str,
+    username: str,
+    password: str,
+    ca_cert_path: str | None = None,
+    timeout: int = 30,
+) -> dict[str, Any]:
+    """GET /pools/default/buckets/@index/stats — index service runtime stats."""
+    scheme, port = _mgmt_base(connection_string)
+    return _get_json(
+        connection_string=connection_string,
+        username=username,
+        password=password,
+        ca_cert_path=ca_cert_path,
+        timeout=timeout,
+        scheme=scheme,
+        port=port,
+        path="/pools/default/buckets/@index/stats",
+    )
+
+
+def get_query_stats_rest(
+    connection_string: str,
+    username: str,
+    password: str,
+    ca_cert_path: str | None = None,
+    timeout: int = 30,
+) -> dict[str, Any]:
+    """GET /pools/default/buckets/@query/stats — query service runtime stats."""
+    scheme, port = _mgmt_base(connection_string)
+    return _get_json(
+        connection_string=connection_string,
+        username=username,
+        password=password,
+        ca_cert_path=ca_cert_path,
+        timeout=timeout,
+        scheme=scheme,
+        port=port,
+        path="/pools/default/buckets/@query/stats",
+    )
+
+
+def get_fts_stats_rest(
+    connection_string: str,
+    username: str,
+    password: str,
+    ca_cert_path: str | None = None,
+    timeout: int = 30,
+) -> dict[str, Any]:
+    """GET /api/nsstats — FTS service stats (on FTS port 8094/18094)."""
+    scheme, port = _fts_base(connection_string)
+    return _get_json(
+        connection_string=connection_string,
+        username=username,
+        password=password,
+        ca_cert_path=ca_cert_path,
+        timeout=timeout,
+        scheme=scheme,
+        port=port,
+        path="/api/nsstats",
+    )
+
+
+def get_kv_stats_rest(
+    connection_string: str,
+    username: str,
+    password: str,
+    bucket_name: str,
+    ca_cert_path: str | None = None,
+    timeout: int = 30,
+) -> dict[str, Any]:
+    """GET /pools/default/buckets/{bucket}/nodes/{node}/stats/curr_items — KV
+    per-node current items count.
+
+    Note: unlike bucket_stats which is aggregated across nodes,
+    ``curr_items`` requires a per-node lookup. For simplicity we return the
+    aggregated bucket stats filtered to KV-relevant keys; a caller who
+    wants per-node breakdowns can use ``get_node_info`` + ``get_bucket_stats``
+    together.
+    """
+    assert_bucket_name(bucket_name)
+    scheme, port = _mgmt_base(connection_string)
+    return _get_json(
+        connection_string=connection_string,
+        username=username,
+        password=password,
+        ca_cert_path=ca_cert_path,
+        timeout=timeout,
+        scheme=scheme,
+        port=port,
+        path=(
+            f"/pools/default/buckets/{_encode_path_segment(bucket_name)}"
+            "/stats/curr_items"
+        ),
+    )
+
+
+def get_error_logs_rest(
+    connection_string: str,
+    username: str,
+    password: str,
+    ca_cert_path: str | None = None,
+    timeout: int = 30,
+) -> dict[str, Any]:
+    """GET /logs — recent server log entries.
+
+    Returns a dict with a ``list`` key holding recent log lines. This is
+    the same view the cluster manager web UI's Logs tab reads.
+    """
+    scheme, port = _mgmt_base(connection_string)
+    return _get_json(
+        connection_string=connection_string,
+        username=username,
+        password=password,
+        ca_cert_path=ca_cert_path,
+        timeout=timeout,
+        scheme=scheme,
+        port=port,
+        path="/logs",
+    )

--- a/src/cb_mcp/utils/fts_rest.py
+++ b/src/cb_mcp/utils/fts_rest.py
@@ -1,0 +1,366 @@
+"""
+REST client for FTS (Full-Text Search) index management endpoints.
+
+FTS admin runs on a dedicated service port (8094 for HTTP, 18094 for TLS).
+The endpoints are:
+
+- ``/api/index`` — GET lists all indexes; PUT ``/api/index/{name}`` creates
+  or updates an index; DELETE ``/api/index/{name}`` removes one.
+- ``/api/index/{name}`` — GET returns the index definition.
+- ``/api/index/{name}/count`` — GET returns document count.
+- ``/api/index/{name}/ingestControl/{op}`` — POST pause / resume ingestion.
+- ``/api/index/{name}/queryControl/{op}`` — POST allow / disallow queries.
+- ``/api/analyzeDoc/{name}`` — POST returns how a document would be
+  analyzed against the given index's mapping.
+
+Verified against Couchbase Server FTS REST API docs 2026-07-06.
+
+Reuses the connection-string host extraction and SSL verification logic
+already present in ``index_utils`` so behavior (Capella root CA handling,
+multi-host fallback, TLS detection) stays consistent with the existing
+REST paths in ``index_settings.py``, ``bucket_admin_rest.py``, and
+``xdcr_rest.py``.
+
+License: MIT - Copyright (c) 2026 Chris Ahrendt
+"""
+
+import json
+import logging
+import re
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from .constants import MCP_SERVER_NAME
+from .index_utils import (
+    _determine_ssl_verification,
+    _extract_hosts_from_connection_string,
+)
+
+logger = logging.getLogger(f"{MCP_SERVER_NAME}.utils.fts_rest")
+
+# Search service ports (distinct from cluster manager 8091/18091 and Index
+# Service 9102).
+_FTS_PORT = 8094
+_FTS_TLS_PORT = 18094
+
+_INDEX_PATH = "/api/index"  # + /{name}
+_ANALYZE_DOC_PATH = "/api/analyzeDoc"  # + /{name}
+
+# Index name: Couchbase FTS accepts letters, digits, dot, dash, underscore,
+# and percent. No slashes (path separator), no whitespace, no control chars.
+_INDEX_NAME_RE = re.compile(r"^[A-Za-z0-9._\-%]{1,200}$")
+
+# Ingest/query control ops. Small allow-lists so a caller can't smuggle an
+# arbitrary controller path.
+ALLOWED_INGEST_OPS: frozenset[str] = frozenset({"pause", "resume"})
+ALLOWED_QUERY_OPS: frozenset[str] = frozenset({"allow", "disallow"})
+
+
+# --------------------------------------------------------------------------
+# Validators
+# --------------------------------------------------------------------------
+
+
+def assert_fts_index_name(name: str) -> None:
+    """Reject FTS index names that don't match Couchbase's documented charset.
+
+    Also prevents path traversal / injection since the value is interpolated
+    into a REST URL path.
+    """
+    if not isinstance(name, str) or not _INDEX_NAME_RE.fullmatch(name):
+        raise ValueError(
+            f"Invalid FTS index name {name!r}. Names must be 1-200 chars "
+            "of [A-Za-z0-9._%-]."
+        )
+
+
+def _encode_path_segment(value: str) -> str:
+    """URL-encode a value for use as a REST path segment.
+
+    Same helper pattern as ``bucket_admin_rest._encode_path_segment`` and
+    ``xdcr_rest._encode_path_segment``. ``%`` is a valid character in FTS
+    index names, and raw interpolation could produce path-confusion
+    vectors if a name were, e.g., ``%2f%2e%2e``. Encoding with ``safe=""``
+    produces the double-encoded form the server treats as an opaque name.
+    """
+    return quote(value, safe="")
+
+
+# --------------------------------------------------------------------------
+# Internals
+# --------------------------------------------------------------------------
+
+
+def _fts_base(connection_string: str) -> tuple[str, int]:
+    """Return (scheme, port) for the FTS service endpoint."""
+    is_tls = connection_string.lower().startswith("couchbases://")
+    return ("https", _FTS_TLS_PORT) if is_tls else ("http", _FTS_PORT)
+
+
+def _request(
+    *,
+    method: str,
+    connection_string: str,
+    username: str,
+    password: str,
+    ca_cert_path: str | None,
+    timeout: int,
+    path: str,
+    json_body: Any = None,
+    expected_ok: tuple[int, ...] = (200, 201, 202),
+) -> dict[str, Any]:
+    """Issue a REST request to the FTS service, trying each host in turn.
+
+    FTS endpoints accept and return JSON. On success returns the parsed JSON
+    body when present, or an empty dict. Raises ``RuntimeError`` if every
+    host fails.
+    """
+    hosts = _extract_hosts_from_connection_string(connection_string)
+    scheme, port = _fts_base(connection_string)
+    verify_ssl = _determine_ssl_verification(connection_string, ca_cert_path)
+
+    last_error: Exception | None = None
+    with httpx.Client(verify=verify_ssl, timeout=timeout) as client:
+        for host in hosts:
+            url = f"{scheme}://{host}:{port}{path}"
+            try:
+                logger.info(f"{method} {url}")
+                headers = (
+                    {"Content-Type": "application/json"}
+                    if json_body is not None
+                    else {}
+                )
+                content = (
+                    json.dumps(json_body).encode("utf-8")
+                    if json_body is not None
+                    else None
+                )
+                if method == "GET":
+                    resp = client.get(url, auth=(username, password))
+                elif method == "DELETE":
+                    resp = client.delete(url, auth=(username, password))
+                elif method == "PUT":
+                    resp = client.put(
+                        url,
+                        content=content,
+                        headers=headers,
+                        auth=(username, password),
+                    )
+                elif method == "POST":
+                    resp = client.post(
+                        url,
+                        content=content,
+                        headers=headers,
+                        auth=(username, password),
+                    )
+                else:
+                    raise ValueError(f"unsupported HTTP method: {method}")
+                if resp.status_code not in expected_ok:
+                    resp.raise_for_status()
+                content_type = resp.headers.get("content-type", "")
+                if resp.content and content_type.startswith("application/json"):
+                    return resp.json()
+                return {}
+            except httpx.HTTPError as e:
+                logger.warning(f"FTS {method} failed on {host}: {e}")
+                last_error = e
+
+    error_msg = f"FTS {method} {path} failed on all hosts: {hosts}"
+    if last_error:
+        error_msg += f". Last error: {last_error}"
+    logger.error(error_msg)
+    raise RuntimeError(error_msg)
+
+
+# --------------------------------------------------------------------------
+# Public REST wrappers
+# --------------------------------------------------------------------------
+
+
+def list_fts_indexes_rest(
+    connection_string: str,
+    username: str,
+    password: str,
+    ca_cert_path: str | None = None,
+    timeout: int = 30,
+) -> dict[str, Any]:
+    """GET /api/index — list all indexes on the cluster."""
+    return _request(
+        method="GET",
+        connection_string=connection_string,
+        username=username,
+        password=password,
+        ca_cert_path=ca_cert_path,
+        timeout=timeout,
+        path=_INDEX_PATH,
+    )
+
+
+def get_fts_index_rest(
+    connection_string: str,
+    username: str,
+    password: str,
+    index_name: str,
+    ca_cert_path: str | None = None,
+    timeout: int = 30,
+) -> dict[str, Any]:
+    """GET /api/index/{name} — return the full index definition."""
+    assert_fts_index_name(index_name)
+    return _request(
+        method="GET",
+        connection_string=connection_string,
+        username=username,
+        password=password,
+        ca_cert_path=ca_cert_path,
+        timeout=timeout,
+        path=f"{_INDEX_PATH}/{_encode_path_segment(index_name)}",
+    )
+
+
+def get_fts_index_count_rest(
+    connection_string: str,
+    username: str,
+    password: str,
+    index_name: str,
+    ca_cert_path: str | None = None,
+    timeout: int = 30,
+) -> dict[str, Any]:
+    """GET /api/index/{name}/count — return document count in the index."""
+    assert_fts_index_name(index_name)
+    return _request(
+        method="GET",
+        connection_string=connection_string,
+        username=username,
+        password=password,
+        ca_cert_path=ca_cert_path,
+        timeout=timeout,
+        path=f"{_INDEX_PATH}/{_encode_path_segment(index_name)}/count",
+    )
+
+
+def create_or_update_fts_index_rest(
+    connection_string: str,
+    username: str,
+    password: str,
+    index_name: str,
+    definition: dict[str, Any],
+    ca_cert_path: str | None = None,
+    timeout: int = 30,
+) -> dict[str, Any]:
+    """PUT /api/index/{name} — create or update an index.
+
+    Couchbase's FTS API uses the same endpoint for create and update; the
+    server distinguishes by whether the index already exists. Callers
+    signal intent via the tool-layer functions ``create_fts_index`` vs.
+    ``update_fts_index``.
+    """
+    assert_fts_index_name(index_name)
+    return _request(
+        method="PUT",
+        connection_string=connection_string,
+        username=username,
+        password=password,
+        ca_cert_path=ca_cert_path,
+        timeout=timeout,
+        path=f"{_INDEX_PATH}/{_encode_path_segment(index_name)}",
+        json_body=definition,
+    )
+
+
+def delete_fts_index_rest(
+    connection_string: str,
+    username: str,
+    password: str,
+    index_name: str,
+    ca_cert_path: str | None = None,
+    timeout: int = 30,
+) -> dict[str, Any]:
+    """DELETE /api/index/{name}."""
+    assert_fts_index_name(index_name)
+    return _request(
+        method="DELETE",
+        connection_string=connection_string,
+        username=username,
+        password=password,
+        ca_cert_path=ca_cert_path,
+        timeout=timeout,
+        path=f"{_INDEX_PATH}/{_encode_path_segment(index_name)}",
+    )
+
+
+def ingest_control_rest(
+    connection_string: str,
+    username: str,
+    password: str,
+    index_name: str,
+    op: str,
+    ca_cert_path: str | None = None,
+    timeout: int = 30,
+) -> dict[str, Any]:
+    """POST /api/index/{name}/ingestControl/{pause|resume}."""
+    assert_fts_index_name(index_name)
+    if op not in ALLOWED_INGEST_OPS:
+        raise ValueError(f"op must be one of {sorted(ALLOWED_INGEST_OPS)}, got {op!r}")
+    return _request(
+        method="POST",
+        connection_string=connection_string,
+        username=username,
+        password=password,
+        ca_cert_path=ca_cert_path,
+        timeout=timeout,
+        path=(f"{_INDEX_PATH}/{_encode_path_segment(index_name)}/ingestControl/{op}"),
+    )
+
+
+def query_control_rest(
+    connection_string: str,
+    username: str,
+    password: str,
+    index_name: str,
+    op: str,
+    ca_cert_path: str | None = None,
+    timeout: int = 30,
+) -> dict[str, Any]:
+    """POST /api/index/{name}/queryControl/{allow|disallow}."""
+    assert_fts_index_name(index_name)
+    if op not in ALLOWED_QUERY_OPS:
+        raise ValueError(f"op must be one of {sorted(ALLOWED_QUERY_OPS)}, got {op!r}")
+    return _request(
+        method="POST",
+        connection_string=connection_string,
+        username=username,
+        password=password,
+        ca_cert_path=ca_cert_path,
+        timeout=timeout,
+        path=(f"{_INDEX_PATH}/{_encode_path_segment(index_name)}/queryControl/{op}"),
+    )
+
+
+def analyze_doc_rest(
+    connection_string: str,
+    username: str,
+    password: str,
+    index_name: str,
+    doc: dict[str, Any],
+    ca_cert_path: str | None = None,
+    timeout: int = 30,
+) -> dict[str, Any]:
+    """POST /api/analyzeDoc/{name} with a JSON document body.
+
+    Returns how the given document would be analyzed against the index's
+    mapping (tokenization, byte offsets, field routing). Useful for
+    debugging analyzer configuration without indexing real data.
+    """
+    assert_fts_index_name(index_name)
+    return _request(
+        method="POST",
+        connection_string=connection_string,
+        username=username,
+        password=password,
+        ca_cert_path=ca_cert_path,
+        timeout=timeout,
+        path=f"{_ANALYZE_DOC_PATH}/{_encode_path_segment(index_name)}",
+        json_body=doc,
+    )

--- a/src/cb_mcp/utils/index_ddl.py
+++ b/src/cb_mcp/utils/index_ddl.py
@@ -1,0 +1,116 @@
+"""
+Index DDL safety primitives.
+
+Identifier quoting and statement allow-listing for the index-management
+tools. These guard the two paths by which a caller can reach index DDL:
+
+1. Structured helper fields (bucket/scope/collection/index names, key
+   fields). Every identifier is backtick-quoted via :func:`safe_ident`
+   before interpolation, so a name containing a backtick cannot break out
+   of its quoting and inject arbitrary SQL++.
+
+2. A raw ``statement`` string. This is convenient but dangerous, so it is
+   constrained by :func:`assert_index_create_ddl` /
+   :func:`assert_index_drop_ddl`, which reject anything that is not the
+   expected index-DDL shape. This prevents the raw path from becoming a
+   general SQL++ execution channel that bypasses read-only and
+   admin-write gating.
+
+License: MIT - Copyright (c) 2026 Chris Ahrendt
+"""
+
+import re
+
+# Allow-list patterns for the raw ``statement`` path. Anchored at the start so
+# a statement must *begin* with the permitted keyword. Note the anchor alone is
+# not sufficient: a statement like "CREATE INDEX ... ; DELETE FROM ..." begins
+# with a permitted keyword but carries a second statement. ``_is_single_statement``
+# below rejects any embedded statement separator so the raw path cannot be used
+# to smuggle a trailing DML/DDL statement past the allow-list.
+_INDEX_CREATE_RE = re.compile(
+    r"""^\s*
+    (
+        CREATE\s+(PRIMARY\s+)?INDEX
+        | CREATE\s+(?:HYPERSCALE\s+|COMPOSITE\s+)?VECTOR\s+INDEX
+    )
+    \b
+    """,
+    re.IGNORECASE | re.VERBOSE,
+)
+
+_INDEX_BUILD_RE = re.compile(r"""^\s*BUILD\s+INDEX\b""", re.IGNORECASE | re.VERBOSE)
+
+_INDEX_DROP_RE = re.compile(
+    r"""^\s*DROP\s+((PRIMARY|VECTOR)\s+)?INDEX\b""",
+    re.IGNORECASE | re.VERBOSE,
+)
+
+
+def _is_single_statement(statement: str) -> bool:
+    """True if *statement* contains no embedded statement separator.
+
+    SQL++ separates statements with ``;``. A trailing semicolon (optionally
+    followed by whitespace) is allowed; a semicolon with anything non-blank
+    after it means a second statement is present and the input is rejected.
+    Backtick-quoted identifiers may legitimately contain a ``;`` inside the
+    quotes, so those spans are removed before the check to avoid false
+    positives on names like ``` `weird;name` ```.
+    """
+    # Strip backtick-quoted spans (identifiers) so a ';' inside a quoted name
+    # is not mistaken for a statement separator. Doubled backticks are escapes.
+    without_idents = re.sub(r"`(?:[^`]|``)*`", "", statement)
+    stripped = without_idents.rstrip()
+    if stripped.endswith(";"):
+        stripped = stripped[:-1]
+    return ";" not in stripped
+
+
+def safe_ident(segment: str) -> str:
+    """Backtick-quote and escape an identifier for SQL++.
+
+    Couchbase SQL++ escapes an embedded backtick by doubling it, so a
+    caller-supplied name can never terminate its own quoting. Applied to
+    every bucket / scope / collection / index / field name before it is
+    interpolated into a statement.
+    """
+    return "`" + (segment or "").replace("`", "``") + "`"
+
+
+def assert_index_create_ddl(statement: str) -> str | None:
+    """Return an error message if *statement* is not permitted index-create DDL.
+
+    Returns ``None`` when the statement is a single CREATE INDEX / CREATE
+    PRIMARY INDEX / CREATE [HYPERSCALE|COMPOSITE] VECTOR INDEX statement. Any
+    other SQL++ - including a permitted statement followed by a second,
+    smuggled statement - is rejected so the raw ``statement`` path cannot be
+    used to run arbitrary queries or DML. (BUILD INDEX is handled by
+    ``build_deferred_indexes``, not this create path.)
+    """
+    stmt = statement or ""
+    if not _INDEX_CREATE_RE.match(stmt) or not _is_single_statement(stmt):
+        return (
+            "The `statement` parameter only accepts a single index-create DDL "
+            "statement (CREATE INDEX, CREATE PRIMARY INDEX, or CREATE "
+            "[HYPERSCALE|COMPOSITE] VECTOR INDEX), with no trailing statement. "
+            "Use the helper fields (index_name, bucket_name, fields, etc.) for "
+            "structured creation, or run other SQL++ via run_sql_plus_plus_query."
+        )
+    return None
+
+
+def assert_index_drop_ddl(statement: str) -> str | None:
+    """Return an error message if *statement* is not permitted index-drop DDL.
+
+    Returns ``None`` when the statement is a single DROP INDEX, DROP PRIMARY
+    INDEX, or DROP VECTOR INDEX statement. Any other SQL++ - including a
+    trailing smuggled statement - is rejected.
+    """
+    stmt = statement or ""
+    if not _INDEX_DROP_RE.match(stmt) or not _is_single_statement(stmt):
+        return (
+            "The `statement` parameter only accepts a single DROP INDEX, DROP "
+            "PRIMARY INDEX, or DROP VECTOR INDEX statement, with no trailing "
+            "statement. Use the helper fields for structured drops, or run "
+            "other SQL++ via run_sql_plus_plus_query."
+        )
+    return None

--- a/src/cb_mcp/utils/index_settings.py
+++ b/src/cb_mcp/utils/index_settings.py
@@ -1,0 +1,155 @@
+"""
+REST client for the Global Secondary Index (GSI) settings endpoint.
+
+The GSI Settings API is served by the cluster manager on port 8091 (18091
+for TLS) at ``/settings/indexes`` - distinct from the Index Service REST API
+(port 9102) used by ``fetch_indexes_from_rest_api`` in ``index_utils``. GET
+returns a JSON object of current settings; POST accepts
+``application/x-www-form-urlencoded`` key-value pairs and leaves unspecified
+parameters unchanged.
+
+Verified against Couchbase Server docs (rest-api/get-settings-indexes,
+post-settings-indexes, rest-index-service) 2026-07-02.
+
+This helper reuses the connection-string host extraction and SSL
+verification logic already present in ``index_utils`` so behavior (Capella
+root CA handling, multi-host fallback, TLS detection) stays consistent with
+the existing index REST path.
+
+License: MIT - Copyright (c) 2026 Chris Ahrendt
+"""
+
+import logging
+from typing import Any
+
+import httpx
+
+from .constants import MCP_SERVER_NAME
+from .index_utils import (
+    _determine_ssl_verification,
+    _extract_hosts_from_connection_string,
+)
+
+logger = logging.getLogger(f"{MCP_SERVER_NAME}.utils.index_settings")
+
+# Cluster-manager ports for the GSI Settings API (NOT the 9102 Index Service
+# port used for /getIndexStatus).
+_GSI_SETTINGS_PORT = 8091
+_GSI_SETTINGS_TLS_PORT = 18091
+_GSI_SETTINGS_PATH = "/settings/indexes"
+
+
+def _settings_base(connection_string: str) -> tuple[str, int]:
+    """Return (scheme, port) for the GSI settings endpoint."""
+    is_tls = connection_string.lower().startswith("couchbases://")
+    return ("https", _GSI_SETTINGS_TLS_PORT) if is_tls else ("http", _GSI_SETTINGS_PORT)
+
+
+def get_gsi_settings(
+    connection_string: str,
+    username: str,
+    password: str,
+    ca_cert_path: str | None = None,
+    timeout: int = 30,
+) -> dict[str, Any]:
+    """GET the current GSI settings from the cluster.
+
+    Tries each host in the connection string until one responds. Raises
+    ``RuntimeError`` if all hosts fail.
+    """
+    return _request_gsi_settings(
+        method="GET",
+        connection_string=connection_string,
+        username=username,
+        password=password,
+        ca_cert_path=ca_cert_path,
+        timeout=timeout,
+    )
+
+
+def set_gsi_settings(
+    connection_string: str,
+    username: str,
+    password: str,
+    params: dict[str, Any],
+    ca_cert_path: str | None = None,
+    timeout: int = 30,
+) -> dict[str, Any]:
+    """POST GSI settings (form-urlencoded) and return the resulting settings.
+
+    ``params`` values are converted to the string forms the endpoint expects
+    (booleans as lowercase ``true``/``false``). Only the supplied keys are
+    sent; unspecified settings are left unchanged by the server. After a
+    successful POST the current settings are read back and returned.
+    """
+    if not params:
+        raise ValueError("params must contain at least one setting to update")
+
+    form = {k: _form_value(v) for k, v in params.items() if v is not None}
+    if not form:
+        raise ValueError("params contained no non-null settings to update")
+
+    _request_gsi_settings(
+        method="POST",
+        connection_string=connection_string,
+        username=username,
+        password=password,
+        ca_cert_path=ca_cert_path,
+        timeout=timeout,
+        data=form,
+    )
+    # Read back so the caller sees the applied state.
+    return get_gsi_settings(
+        connection_string, username, password, ca_cert_path, timeout
+    )
+
+
+def _form_value(value: Any) -> str:
+    """Render a value for the form-urlencoded body (bools lowercased)."""
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    return str(value)
+
+
+def _request_gsi_settings(
+    *,
+    method: str,
+    connection_string: str,
+    username: str,
+    password: str,
+    ca_cert_path: str | None,
+    timeout: int,
+    data: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    """Issue a GET/POST to /settings/indexes, trying each host in turn."""
+    hosts = _extract_hosts_from_connection_string(connection_string)
+    scheme, port = _settings_base(connection_string)
+    verify_ssl = _determine_ssl_verification(connection_string, ca_cert_path)
+
+    last_error: Exception | None = None
+    with httpx.Client(verify=verify_ssl, timeout=timeout) as client:
+        for host in hosts:
+            url = f"{scheme}://{host}:{port}{_GSI_SETTINGS_PATH}"
+            try:
+                logger.info(f"{method} {url}")
+                if method == "GET":
+                    resp = client.get(url, auth=(username, password))
+                else:
+                    resp = client.post(url, data=data, auth=(username, password))
+                resp.raise_for_status()
+                # GET returns settings JSON; POST returns an empty/!json body
+                # on some versions, so only parse when there is content.
+                if resp.content and resp.headers.get("content-type", "").startswith(
+                    "application/json"
+                ):
+                    return resp.json()
+                return {}
+            except httpx.HTTPError as e:
+                logger.warning(f"GSI settings {method} failed on {host}: {e}")
+                last_error = e
+
+    error_msg = f"GSI settings {method} failed on all hosts: {hosts}"
+    if last_error:
+        error_msg += f". Last error: {last_error}"
+    logger.error(error_msg)
+    raise RuntimeError(error_msg)

--- a/src/cb_mcp/utils/xdcr_rest.py
+++ b/src/cb_mcp/utils/xdcr_rest.py
@@ -1,0 +1,410 @@
+"""
+REST client for XDCR (Cross-Datacenter Replication) admin endpoints.
+
+XDCR admin is split across three endpoint families:
+
+- ``/pools/default/remoteClusters[/{name}]`` — remote-cluster references
+  (create/list/update/delete on port 8091/18091).
+- ``/controller/createReplication`` and ``/controller/cancelXDCR/{id}`` —
+  replication lifecycle actions.
+- ``/settings/replications[/{id}]`` — per-replication and cluster-wide
+  replication settings (throttling, filter expressions, priority, pause
+  state). GET returns JSON; POST accepts form-urlencoded pairs.
+
+Verified against Couchbase Server docs (rest-api/rest-xdcr-*, xdcr-managing)
+2026-07-06.
+
+This helper reuses the connection-string host extraction and SSL
+verification logic already present in ``index_utils`` so behavior (Capella
+root CA handling, multi-host fallback, TLS detection) stays consistent
+with the existing REST paths in ``index_settings.py`` and
+``bucket_admin_rest.py``.
+
+License: MIT - Copyright (c) 2026 Chris Ahrendt
+"""
+
+import json
+import logging
+import re
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from .constants import MCP_SERVER_NAME
+from .index_utils import (
+    _determine_ssl_verification,
+    _extract_hosts_from_connection_string,
+)
+
+logger = logging.getLogger(f"{MCP_SERVER_NAME}.utils.xdcr_rest")
+
+# Cluster-manager ports (same as GSI settings and bucket admin).
+_MGMT_PORT = 8091
+_MGMT_TLS_PORT = 18091
+
+_REMOTE_CLUSTERS_PATH = "/pools/default/remoteClusters"
+_CREATE_REPLICATION_PATH = "/controller/createReplication"
+_CANCEL_REPLICATION_PATH = "/controller/cancelXDCR"  # + /{replication_id}
+_REPLICATION_SETTINGS_PATH = "/settings/replications"  # + /{replication_id}
+
+# Remote-cluster name: same charset as bucket name per Couchbase docs
+# (letters, digits, and ``.``, ``-``, ``_``, ``%``). Reject anything else
+# BEFORE it enters a URL path.
+_REMOTE_CLUSTER_NAME_RE = re.compile(r"^[A-Za-z0-9._\-%]{1,100}$")
+
+# Replication ID: cluster-generated as ``{uuid}/{sourceBucket}/{targetBucket}``.
+# Contains slashes, so this validator rejects control chars and things that
+# would break URL parsing, not the slashes themselves. Each segment is
+# path-encoded individually before use.
+_REPLICATION_ID_SEGMENT_RE = re.compile(r"^[A-Za-z0-9._\-%]{1,100}$")
+
+
+# --------------------------------------------------------------------------
+# Validators
+# --------------------------------------------------------------------------
+
+
+def assert_remote_cluster_name(name: str) -> None:
+    """Reject remote-cluster names that don't match Couchbase's charset."""
+    if not isinstance(name, str) or not _REMOTE_CLUSTER_NAME_RE.fullmatch(name):
+        raise ValueError(
+            f"Invalid remote-cluster name {name!r}. Names must be 1-100 "
+            "chars of [A-Za-z0-9._%-]."
+        )
+
+
+def assert_replication_id(replication_id: str) -> None:
+    """Reject replication IDs that don't fit the ``uuid/src/tgt`` shape.
+
+    Each of the three slash-separated segments is checked against
+    ``_REPLICATION_ID_SEGMENT_RE`` (letters, digits, ``.``, ``-``, ``_``,
+    ``%``). Raises ``ValueError`` on any deviation.
+    """
+    if not isinstance(replication_id, str) or "/" not in replication_id:
+        raise ValueError(
+            f"Invalid replication ID {replication_id!r}. Expected the "
+            "cluster-generated ``uuid/sourceBucket/targetBucket`` form."
+        )
+    segments = replication_id.split("/")
+    if len(segments) != 3:
+        raise ValueError(
+            f"Invalid replication ID {replication_id!r}. Expected exactly "
+            f"three segments (uuid/src/tgt), got {len(segments)}."
+        )
+    for i, seg in enumerate(segments):
+        if not _REPLICATION_ID_SEGMENT_RE.fullmatch(seg):
+            raise ValueError(
+                f"Invalid replication ID segment {seg!r} at index {i}. "
+                "Each segment must be 1-100 chars of [A-Za-z0-9._%-]."
+            )
+
+
+def _encode_path_segment(value: str) -> str:
+    """URL-encode a value for use as a REST path segment.
+
+    Same helper pattern as ``bucket_admin_rest._encode_path_segment``:
+    ``%`` is a valid character in Couchbase names, and raw interpolation
+    could produce path-confusion vectors if a name were, e.g., ``%2f%2e%2e``.
+    Encoding with ``safe=""`` produces ``%252f%252e%252e``, which the
+    server treats as an opaque identifier.
+    """
+    return quote(value, safe="")
+
+
+def _encoded_replication_id(replication_id: str) -> str:
+    """Encode a replication ID's three segments individually so slashes
+    between segments survive but slashes WITHIN a segment (never legal in
+    Couchbase names) would be double-encoded."""
+    assert_replication_id(replication_id)
+    return "/".join(_encode_path_segment(s) for s in replication_id.split("/"))
+
+
+# --------------------------------------------------------------------------
+# Small internals shared by every REST call
+# --------------------------------------------------------------------------
+
+
+def _mgmt_base(connection_string: str) -> tuple[str, int]:
+    """Return (scheme, port) for the cluster-manager endpoint."""
+    is_tls = connection_string.lower().startswith("couchbases://")
+    return ("https", _MGMT_TLS_PORT) if is_tls else ("http", _MGMT_PORT)
+
+
+def _form_value(value: Any) -> str:
+    """Render a value for the form-urlencoded body.
+
+    XDCR endpoints follow the same convention as bucket admin: bools as
+    lowercase ``true``/``false``, ints bare, dicts as JSON (some XDCR
+    settings take nested objects), other values as str().
+    """
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, int | float):
+        return str(value)
+    if isinstance(value, dict):
+        return json.dumps(value)
+    return str(value)
+
+
+def _request(
+    *,
+    method: str,
+    connection_string: str,
+    username: str,
+    password: str,
+    ca_cert_path: str | None,
+    timeout: int,
+    path: str,
+    data: dict[str, str] | None = None,
+    expected_ok: tuple[int, ...] = (200, 202),
+) -> dict[str, Any]:
+    """Issue a REST request to the cluster manager, trying each host in turn.
+
+    On success returns the parsed JSON body when present, or an empty dict
+    (many XDCR endpoints return an empty body on 200/202). Raises
+    ``RuntimeError`` if every host fails.
+    """
+    hosts = _extract_hosts_from_connection_string(connection_string)
+    scheme, port = _mgmt_base(connection_string)
+    verify_ssl = _determine_ssl_verification(connection_string, ca_cert_path)
+
+    last_error: Exception | None = None
+    with httpx.Client(verify=verify_ssl, timeout=timeout) as client:
+        for host in hosts:
+            url = f"{scheme}://{host}:{port}{path}"
+            try:
+                logger.info(f"{method} {url}")
+                if method == "GET":
+                    resp = client.get(url, auth=(username, password))
+                elif method == "DELETE":
+                    resp = client.delete(url, auth=(username, password))
+                elif method == "POST":
+                    resp = client.post(url, data=data, auth=(username, password))
+                else:
+                    raise ValueError(f"unsupported HTTP method: {method}")
+                if resp.status_code not in expected_ok:
+                    resp.raise_for_status()
+                content_type = resp.headers.get("content-type", "")
+                if resp.content and content_type.startswith("application/json"):
+                    return resp.json()
+                return {}
+            except httpx.HTTPError as e:
+                logger.warning(f"XDCR {method} failed on {host}: {e}")
+                last_error = e
+
+    error_msg = f"XDCR {method} {path} failed on all hosts: {hosts}"
+    if last_error:
+        error_msg += f". Last error: {last_error}"
+    logger.error(error_msg)
+    raise RuntimeError(error_msg)
+
+
+# --------------------------------------------------------------------------
+# Remote-cluster REST wrappers
+# --------------------------------------------------------------------------
+
+
+def create_remote_cluster_rest(
+    connection_string: str,
+    username: str,
+    password: str,
+    form: dict[str, Any],
+    ca_cert_path: str | None = None,
+    timeout: int = 30,
+) -> dict[str, Any]:
+    """POST /pools/default/remoteClusters."""
+    body = {k: _form_value(v) for k, v in form.items() if v is not None}
+    return _request(
+        method="POST",
+        connection_string=connection_string,
+        username=username,
+        password=password,
+        ca_cert_path=ca_cert_path,
+        timeout=timeout,
+        path=_REMOTE_CLUSTERS_PATH,
+        data=body,
+    )
+
+
+def update_remote_cluster_rest(
+    connection_string: str,
+    username: str,
+    password: str,
+    name: str,
+    form: dict[str, Any],
+    ca_cert_path: str | None = None,
+    timeout: int = 30,
+) -> dict[str, Any]:
+    """POST /pools/default/remoteClusters/{name}."""
+    assert_remote_cluster_name(name)
+    body = {k: _form_value(v) for k, v in form.items() if v is not None}
+    return _request(
+        method="POST",
+        connection_string=connection_string,
+        username=username,
+        password=password,
+        ca_cert_path=ca_cert_path,
+        timeout=timeout,
+        path=f"{_REMOTE_CLUSTERS_PATH}/{_encode_path_segment(name)}",
+        data=body,
+    )
+
+
+def delete_remote_cluster_rest(
+    connection_string: str,
+    username: str,
+    password: str,
+    name: str,
+    ca_cert_path: str | None = None,
+    timeout: int = 30,
+) -> dict[str, Any]:
+    """DELETE /pools/default/remoteClusters/{name}."""
+    assert_remote_cluster_name(name)
+    return _request(
+        method="DELETE",
+        connection_string=connection_string,
+        username=username,
+        password=password,
+        ca_cert_path=ca_cert_path,
+        timeout=timeout,
+        path=f"{_REMOTE_CLUSTERS_PATH}/{_encode_path_segment(name)}",
+    )
+
+
+def list_remote_clusters_rest(
+    connection_string: str,
+    username: str,
+    password: str,
+    ca_cert_path: str | None = None,
+    timeout: int = 30,
+) -> list[dict[str, Any]] | dict[str, Any]:
+    """GET /pools/default/remoteClusters — returns a list of remote-cluster refs."""
+    return _request(
+        method="GET",
+        connection_string=connection_string,
+        username=username,
+        password=password,
+        ca_cert_path=ca_cert_path,
+        timeout=timeout,
+        path=_REMOTE_CLUSTERS_PATH,
+    )
+
+
+# --------------------------------------------------------------------------
+# Replication REST wrappers
+# --------------------------------------------------------------------------
+
+
+def create_replication_rest(
+    connection_string: str,
+    username: str,
+    password: str,
+    form: dict[str, Any],
+    ca_cert_path: str | None = None,
+    timeout: int = 30,
+) -> dict[str, Any]:
+    """POST /controller/createReplication."""
+    body = {k: _form_value(v) for k, v in form.items() if v is not None}
+    return _request(
+        method="POST",
+        connection_string=connection_string,
+        username=username,
+        password=password,
+        ca_cert_path=ca_cert_path,
+        timeout=timeout,
+        path=_CREATE_REPLICATION_PATH,
+        data=body,
+    )
+
+
+def delete_replication_rest(
+    connection_string: str,
+    username: str,
+    password: str,
+    replication_id: str,
+    ca_cert_path: str | None = None,
+    timeout: int = 30,
+) -> dict[str, Any]:
+    """DELETE /controller/cancelXDCR/{replication_id}."""
+    return _request(
+        method="DELETE",
+        connection_string=connection_string,
+        username=username,
+        password=password,
+        ca_cert_path=ca_cert_path,
+        timeout=timeout,
+        path=f"{_CANCEL_REPLICATION_PATH}/{_encoded_replication_id(replication_id)}",
+    )
+
+
+def get_replication_settings_rest(
+    connection_string: str,
+    username: str,
+    password: str,
+    replication_id: str,
+    ca_cert_path: str | None = None,
+    timeout: int = 30,
+) -> dict[str, Any]:
+    """GET /settings/replications/{replication_id}."""
+    return _request(
+        method="GET",
+        connection_string=connection_string,
+        username=username,
+        password=password,
+        ca_cert_path=ca_cert_path,
+        timeout=timeout,
+        path=f"{_REPLICATION_SETTINGS_PATH}/{_encoded_replication_id(replication_id)}",
+    )
+
+
+def update_replication_settings_rest(
+    connection_string: str,
+    username: str,
+    password: str,
+    replication_id: str,
+    form: dict[str, Any],
+    ca_cert_path: str | None = None,
+    timeout: int = 30,
+) -> dict[str, Any]:
+    """POST /settings/replications/{replication_id}."""
+    if not form:
+        raise ValueError("form must contain at least one setting to update")
+    body = {k: _form_value(v) for k, v in form.items() if v is not None}
+    return _request(
+        method="POST",
+        connection_string=connection_string,
+        username=username,
+        password=password,
+        ca_cert_path=ca_cert_path,
+        timeout=timeout,
+        path=f"{_REPLICATION_SETTINGS_PATH}/{_encoded_replication_id(replication_id)}",
+        data=body,
+    )
+
+
+def list_replications_rest(
+    connection_string: str,
+    username: str,
+    password: str,
+    ca_cert_path: str | None = None,
+    timeout: int = 30,
+) -> list[dict[str, Any]]:
+    """GET /pools/default/tasks — filtered to XDCR tasks only.
+
+    The tasks endpoint returns rebalance status, compaction tasks, and
+    XDCR replications in a single array. We filter to ``type='xdcr'`` for
+    the caller.
+    """
+    result = _request(
+        method="GET",
+        connection_string=connection_string,
+        username=username,
+        password=password,
+        ca_cert_path=ca_cert_path,
+        timeout=timeout,
+        path="/pools/default/tasks",
+    )
+    if isinstance(result, list):
+        return [t for t in result if isinstance(t, dict) and t.get("type") == "xdcr"]
+    return []

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -86,6 +86,13 @@ logger = logging.getLogger(MCP_SERVER_NAME)
     help="Enable read-only mode. When True, all write operations (KV and Query) are disabled and KV write tools are not loaded. Set to False to enable write operations.",
 )
 @click.option(
+    "--admin-write-mode",
+    envvar="CB_MCP_ADMIN_WRITE_MODE",
+    type=bool,
+    default=False,
+    help="Enable admin write tools (index DDL and GSI settings). Requires read-only mode to be False. When False, cluster-structure and index-settings mutation tools are not loaded even if data (KV) writes are enabled.",
+)
+@click.option(
     "--transport",
     envvar=[
         "CB_MCP_TRANSPORT"
@@ -212,6 +219,7 @@ def main(
     client_cert_path,
     client_key_path,
     read_only_mode,
+    admin_write_mode,
     transport,
     host,
     port,
@@ -260,6 +268,7 @@ def main(
         disabled_tools=disabled_tools,
         confirmation_required_tools=confirmation_required_tools,
         enforce_scopes=auth is not None,
+        admin_write_mode=admin_write_mode,
     )
 
     # CLI-resolved configuration lives on AppContext, not in a module global.
@@ -272,6 +281,7 @@ def main(
         "client_cert_path": client_cert_path,
         "client_key_path": client_key_path,
         "read_only_mode": read_only_mode,
+        "admin_write_mode": admin_write_mode,
         "transport": transport,
         "host": host,
         "port": port,
@@ -298,7 +308,8 @@ def main(
         """Build the lifespan AppContext with settings captured from the CLI."""
         logger.info(
             f"MCP server initialized in lazy mode for tool discovery. "
-            f"Modes: (read_only_mode={read_only_mode})"
+            f"Modes: (read_only_mode={read_only_mode}, "
+            f"admin_write_mode={admin_write_mode})"
         )
         # Diagnostic snapshot for customer support. Filtered at INFO; visible
         # whenever the user runs with --log-level DEBUG.
@@ -329,7 +340,8 @@ def main(
     mcp = FastMCP(MCP_SERVER_NAME, lifespan=app_lifespan, auth=auth)
 
     logger.info(
-        f"Registering {len(final_tools)} tool(s) with modes (read_only_mode={read_only_mode})"
+        f"Registering {len(final_tools)} tool(s) with modes "
+        f"(read_only_mode={read_only_mode}, admin_write_mode={admin_write_mode})"
     )
 
     # Register tools; FastMCP 3.x add_tool has no annotations kwarg, so wrap first.

--- a/tests/unit/test_collections_admin.py
+++ b/tests/unit/test_collections_admin.py
@@ -1,0 +1,432 @@
+"""
+Unit tests for the scope/collection management tool bodies (parameter
+validation, argument construction, confirmation gates, and write-scope
+gating), exercised against stubbed CollectionManager / cluster objects
+so no live Couchbase cluster is required.
+
+License: MIT - Copyright (c) 2026 Chris Ahrendt
+"""
+
+from contextlib import contextmanager
+from datetime import timedelta
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from cb_mcp.tools.collections_admin import (
+    _require_write_scope,
+    _timedelta_or_none,
+    create_collection,
+    create_scope,
+    drop_collection,
+    drop_scope,
+    get_collection_settings,
+    update_collection,
+)
+from cb_mcp.utils.constants import SCOPE_WRITE
+
+# --------------------------------------------------------------------------
+# Helpers
+# --------------------------------------------------------------------------
+
+
+@contextmanager
+def _mock_token(scopes):
+    """Patch get_access_token at the collections_admin call site."""
+
+    class _Tok:
+        def __init__(self, scopes_):
+            self.scopes = scopes_
+
+    token = _Tok(scopes) if scopes is not None else None
+    with patch("cb_mcp.tools.collections_admin.get_access_token", return_value=token):
+        yield
+
+
+def _ctx():
+    """Minimal Context stub — the tools pass it to helper functions we stub."""
+    return SimpleNamespace()
+
+
+def _stub_cluster_bucket(monkeypatch, coll_mgr=None):
+    """Stub get_cluster_connection and connect_to_bucket so we get a
+    controllable CollectionManager mock back."""
+    coll_mgr = coll_mgr or MagicMock()
+    bucket = MagicMock()
+    bucket.collections.return_value = coll_mgr
+    cluster = MagicMock()
+    monkeypatch.setattr(
+        "cb_mcp.tools.collections_admin.get_cluster_connection",
+        lambda ctx: cluster,
+    )
+    monkeypatch.setattr(
+        "cb_mcp.tools.collections_admin.connect_to_bucket",
+        lambda cluster, bucket_name: bucket,
+    )
+    return coll_mgr
+
+
+CTX = _ctx()
+
+
+# --------------------------------------------------------------------------
+# _timedelta_or_none
+# --------------------------------------------------------------------------
+
+
+def test_timedelta_or_none_none():
+    assert _timedelta_or_none(None) is None
+
+
+def test_timedelta_or_none_zero():
+    """Zero is 'no TTL', explicit — must return timedelta(0), not None."""
+    assert _timedelta_or_none(0) == timedelta(seconds=0)
+
+
+def test_timedelta_or_none_positive():
+    assert _timedelta_or_none(3600) == timedelta(seconds=3600)
+
+
+def test_timedelta_or_none_negative_rejected():
+    with pytest.raises(ValueError, match="cannot be negative"):
+        _timedelta_or_none(-1)
+
+
+# --------------------------------------------------------------------------
+# _require_write_scope
+# --------------------------------------------------------------------------
+
+
+def test_require_write_scope_noop_without_token():
+    with _mock_token(None):
+        _require_write_scope()
+
+
+def test_require_write_scope_raises_when_missing():
+    with _mock_token(["read"]), pytest.raises(PermissionError, match="write"):
+        _require_write_scope()
+
+
+def test_require_write_scope_passes_when_present():
+    with _mock_token(["read", SCOPE_WRITE]):
+        _require_write_scope()
+
+
+# --------------------------------------------------------------------------
+# create_scope
+# --------------------------------------------------------------------------
+
+
+def test_create_scope_calls_sdk_create_scope(monkeypatch):
+    coll_mgr = _stub_cluster_bucket(monkeypatch)
+    with _mock_token(None):
+        result = create_scope(CTX, bucket_name="b1", scope_name="s1")
+    coll_mgr.create_scope.assert_called_once_with("s1")
+    assert result == {"bucket": "b1", "scope": "s1", "created": True}
+
+
+def test_create_scope_propagates_sdk_error(monkeypatch):
+    coll_mgr = _stub_cluster_bucket(monkeypatch)
+    coll_mgr.create_scope.side_effect = RuntimeError("boom")
+    with _mock_token(None), pytest.raises(RuntimeError, match="boom"):
+        create_scope(CTX, bucket_name="b1", scope_name="s1")
+
+
+# --------------------------------------------------------------------------
+# drop_scope
+# --------------------------------------------------------------------------
+
+
+def test_drop_scope_requires_confirm_true():
+    with _mock_token(None), pytest.raises(ValueError, match="confirm=True"):
+        drop_scope(CTX, bucket_name="b1", scope_name="s1")
+
+
+def test_drop_scope_requires_matching_confirm_name():
+    with _mock_token(None), pytest.raises(ValueError, match="confirm_name"):
+        drop_scope(
+            CTX,
+            bucket_name="b1",
+            scope_name="s1",
+            confirm=True,
+            confirm_name="other",
+        )
+
+
+def test_drop_scope_requires_confirm_name_explicitly():
+    with _mock_token(None), pytest.raises(ValueError, match="confirm_name"):
+        drop_scope(CTX, bucket_name="b1", scope_name="s1", confirm=True)
+
+
+def test_drop_scope_rejects_default_scope():
+    with _mock_token(None), pytest.raises(ValueError, match="_default scope"):
+        drop_scope(
+            CTX,
+            bucket_name="b1",
+            scope_name="_default",
+            confirm=True,
+            confirm_name="_default",
+        )
+
+
+def test_drop_scope_succeeds_with_matching_name(monkeypatch):
+    coll_mgr = _stub_cluster_bucket(monkeypatch)
+    with _mock_token(None):
+        result = drop_scope(
+            CTX,
+            bucket_name="b1",
+            scope_name="s1",
+            confirm=True,
+            confirm_name="s1",
+        )
+    coll_mgr.drop_scope.assert_called_once_with("s1")
+    assert result == {"bucket": "b1", "scope": "s1", "dropped": True}
+
+
+# --------------------------------------------------------------------------
+# create_collection
+# --------------------------------------------------------------------------
+
+
+def test_create_collection_minimal(monkeypatch):
+    coll_mgr = _stub_cluster_bucket(monkeypatch)
+    with _mock_token(None):
+        result = create_collection(
+            CTX,
+            bucket_name="b1",
+            scope_name="s1",
+            collection_name="c1",
+        )
+    call = coll_mgr.create_collection.call_args
+    spec = call.args[0]
+    assert spec.name == "c1"
+    assert spec.scope_name == "s1"
+    assert result["created"] is True
+
+
+def test_create_collection_with_ttl_and_history(monkeypatch):
+    coll_mgr = _stub_cluster_bucket(monkeypatch)
+    with _mock_token(None):
+        result = create_collection(
+            CTX,
+            bucket_name="b1",
+            scope_name="s1",
+            collection_name="c1",
+            max_expiry_seconds=3600,
+            history=True,
+        )
+    spec = coll_mgr.create_collection.call_args.args[0]
+    assert spec.max_expiry == timedelta(seconds=3600)
+    assert spec.history is True
+    assert result["max_expiry_seconds"] == 3600
+    assert result["history"] is True
+
+
+def test_create_collection_zero_ttl_means_no_expiry(monkeypatch):
+    """max_expiry_seconds=0 means 'no TTL', distinct from None ('inherit')."""
+    coll_mgr = _stub_cluster_bucket(monkeypatch)
+    with _mock_token(None):
+        create_collection(
+            CTX,
+            bucket_name="b1",
+            scope_name="s1",
+            collection_name="c1",
+            max_expiry_seconds=0,
+        )
+    spec = coll_mgr.create_collection.call_args.args[0]
+    assert spec.max_expiry == timedelta(seconds=0)
+
+
+def test_create_collection_negative_ttl_rejected():
+    with _mock_token(None), pytest.raises(ValueError, match="cannot be negative"):
+        create_collection(
+            CTX,
+            bucket_name="b1",
+            scope_name="s1",
+            collection_name="c1",
+            max_expiry_seconds=-5,
+        )
+
+
+# --------------------------------------------------------------------------
+# drop_collection
+# --------------------------------------------------------------------------
+
+
+def test_drop_collection_requires_confirm_true():
+    with _mock_token(None), pytest.raises(ValueError, match="confirm=True"):
+        drop_collection(CTX, bucket_name="b1", scope_name="s1", collection_name="c1")
+
+
+def test_drop_collection_requires_matching_confirm_name():
+    with _mock_token(None), pytest.raises(ValueError, match="confirm_name"):
+        drop_collection(
+            CTX,
+            bucket_name="b1",
+            scope_name="s1",
+            collection_name="c1",
+            confirm=True,
+            confirm_name="c2",
+        )
+
+
+def test_drop_collection_rejects_default_default():
+    with _mock_token(None), pytest.raises(ValueError, match="_default"):
+        drop_collection(
+            CTX,
+            bucket_name="b1",
+            scope_name="_default",
+            collection_name="_default",
+            confirm=True,
+            confirm_name="_default",
+        )
+
+
+def test_drop_collection_allows_default_scope_non_default_collection(monkeypatch):
+    """A user-created collection in the _default scope IS droppable."""
+    coll_mgr = _stub_cluster_bucket(monkeypatch)
+    with _mock_token(None):
+        result = drop_collection(
+            CTX,
+            bucket_name="b1",
+            scope_name="_default",
+            collection_name="my_coll",
+            confirm=True,
+            confirm_name="my_coll",
+        )
+    coll_mgr.drop_collection.assert_called_once()
+    assert result["dropped"] is True
+
+
+def test_drop_collection_succeeds(monkeypatch):
+    coll_mgr = _stub_cluster_bucket(monkeypatch)
+    with _mock_token(None):
+        result = drop_collection(
+            CTX,
+            bucket_name="b1",
+            scope_name="s1",
+            collection_name="c1",
+            confirm=True,
+            confirm_name="c1",
+        )
+    spec = coll_mgr.drop_collection.call_args.args[0]
+    assert spec.name == "c1"
+    assert spec.scope_name == "s1"
+    assert result["dropped"] is True
+
+
+# --------------------------------------------------------------------------
+# update_collection
+# --------------------------------------------------------------------------
+
+
+def test_update_collection_requires_at_least_one_change():
+    with _mock_token(None), pytest.raises(ValueError, match="at least one"):
+        update_collection(CTX, bucket_name="b1", scope_name="s1", collection_name="c1")
+
+
+def test_update_collection_ttl_only(monkeypatch):
+    coll_mgr = _stub_cluster_bucket(monkeypatch)
+    with _mock_token(None):
+        result = update_collection(
+            CTX,
+            bucket_name="b1",
+            scope_name="s1",
+            collection_name="c1",
+            max_expiry_seconds=7200,
+        )
+    spec = coll_mgr.update_collection.call_args.args[0]
+    assert spec.max_expiry == timedelta(seconds=7200)
+    assert result["updated"] is True
+
+
+def test_update_collection_history_only(monkeypatch):
+    coll_mgr = _stub_cluster_bucket(monkeypatch)
+    with _mock_token(None):
+        update_collection(
+            CTX,
+            bucket_name="b1",
+            scope_name="s1",
+            collection_name="c1",
+            history=False,
+        )
+    spec = coll_mgr.update_collection.call_args.args[0]
+    assert spec.history is False
+
+
+# --------------------------------------------------------------------------
+# get_collection_settings
+# --------------------------------------------------------------------------
+
+
+def _fake_scope_spec(name, collections):
+    """Build a minimal object shaped like the SDK's ScopeSpec."""
+    scope = SimpleNamespace(name=name, collections=collections)
+    return scope
+
+
+def _fake_collection_spec(name, max_expiry=None, history=None):
+    c = SimpleNamespace(name=name)
+    if max_expiry is not None:
+        c.max_expiry = max_expiry
+    if history is not None:
+        c.history = history
+    return c
+
+
+def test_get_collection_settings_returns_ttl_and_history(monkeypatch):
+    coll = _fake_collection_spec("c1", max_expiry=timedelta(seconds=1800), history=True)
+    scope = _fake_scope_spec("s1", [coll])
+    coll_mgr = MagicMock()
+    coll_mgr.get_all_scopes.return_value = [scope]
+    _stub_cluster_bucket(monkeypatch, coll_mgr=coll_mgr)
+
+    result = get_collection_settings(
+        CTX, bucket_name="b1", scope_name="s1", collection_name="c1"
+    )
+    assert result == {
+        "bucket": "b1",
+        "scope": "s1",
+        "collection": "c1",
+        "max_expiry_seconds": 1800,
+        "history": True,
+    }
+
+
+def test_get_collection_settings_none_max_expiry(monkeypatch):
+    """When the SDK returns no max_expiry, we return None (not 0)."""
+    coll = _fake_collection_spec("c1", history=False)
+    scope = _fake_scope_spec("s1", [coll])
+    coll_mgr = MagicMock()
+    coll_mgr.get_all_scopes.return_value = [scope]
+    _stub_cluster_bucket(monkeypatch, coll_mgr=coll_mgr)
+
+    result = get_collection_settings(
+        CTX, bucket_name="b1", scope_name="s1", collection_name="c1"
+    )
+    assert result["max_expiry_seconds"] is None
+    assert result["history"] is False
+
+
+def test_get_collection_settings_scope_not_found(monkeypatch):
+    coll_mgr = MagicMock()
+    coll_mgr.get_all_scopes.return_value = [_fake_scope_spec("other", [])]
+    _stub_cluster_bucket(monkeypatch, coll_mgr=coll_mgr)
+
+    with pytest.raises(ValueError, match="Scope 's1' not found"):
+        get_collection_settings(
+            CTX, bucket_name="b1", scope_name="s1", collection_name="c1"
+        )
+
+
+def test_get_collection_settings_collection_not_found(monkeypatch):
+    scope = _fake_scope_spec("s1", [_fake_collection_spec("other")])
+    coll_mgr = MagicMock()
+    coll_mgr.get_all_scopes.return_value = [scope]
+    _stub_cluster_bucket(monkeypatch, coll_mgr=coll_mgr)
+
+    with pytest.raises(ValueError, match="Collection 'c1' not found"):
+        get_collection_settings(
+            CTX, bucket_name="b1", scope_name="s1", collection_name="c1"
+        )

--- a/tests/unit/test_diagnostics.py
+++ b/tests/unit/test_diagnostics.py
@@ -1,0 +1,409 @@
+"""
+Unit tests for the diagnostics tool bodies (URL construction, subset
+extraction, and slow-query SQL construction).
+
+License: MIT - Copyright (c) 2026 Chris Ahrendt
+"""
+
+import inspect
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from cb_mcp.tools.diagnostics import (
+    get_bucket_stats,
+    get_cluster_info,
+    get_cluster_stats,
+    get_disk_usage,
+    get_error_logs,
+    get_fts_stats,
+    get_index_stats,
+    get_kv_stats,
+    get_node_info,
+    get_query_stats,
+    get_slow_queries,
+)
+from cb_mcp.utils import diagnostics_rest
+
+# --------------------------------------------------------------------------
+# Fixtures / helpers
+# --------------------------------------------------------------------------
+
+
+def _ctx():
+    settings = {
+        "connection_string": "couchbase://localhost",
+        "username": "Administrator",
+        "password": "password",
+        "ca_cert_path": None,
+    }
+    lifespan = SimpleNamespace(settings=settings)
+    request = SimpleNamespace(lifespan_context=lifespan)
+    return SimpleNamespace(request_context=request)
+
+
+def _stub_httpx_client(json_body=None):
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.content = b'{"ok":true}'
+    resp.headers = {"content-type": "application/json"}
+    resp.json.return_value = json_body if json_body is not None else {"ok": True}
+    resp.raise_for_status = MagicMock()
+
+    client = MagicMock()
+    client.get.return_value = resp
+
+    ctx_mgr = MagicMock()
+    ctx_mgr.__enter__.return_value = client
+    ctx_mgr.__exit__.return_value = False
+    return ctx_mgr, client
+
+
+CTX = _ctx()
+
+
+# --------------------------------------------------------------------------
+# get_cluster_info / get_cluster_stats
+# --------------------------------------------------------------------------
+
+
+def test_get_cluster_info_returns_raw_response(monkeypatch):
+    monkeypatch.setattr(
+        "cb_mcp.tools.diagnostics.get_pools_default_rest",
+        lambda **_: {"nodes": [], "storageTotals": {}, "balanced": True},
+    )
+    result = get_cluster_info(CTX)
+    assert result == {"nodes": [], "storageTotals": {}, "balanced": True}
+
+
+def test_get_cluster_stats_synthesizes_summary(monkeypatch):
+    monkeypatch.setattr(
+        "cb_mcp.tools.diagnostics.get_pools_default_rest",
+        lambda **_: {
+            "nodes": [
+                {"status": "healthy"},
+                {"status": "healthy"},
+                {"status": "warmup"},
+            ],
+            "storageTotals": {"ram": {"total": 100}},
+            "balanced": True,
+            "rebalanceStatus": "none",
+        },
+    )
+    result = get_cluster_stats(CTX)
+    assert result["node_count"] == 3
+    assert result["healthy_nodes"] == 2
+    assert result["storage_totals"] == {"ram": {"total": 100}}
+    assert result["balanced"] is True
+    assert result["rebalance_status"] == "none"
+
+
+def test_get_cluster_stats_handles_empty_response(monkeypatch):
+    monkeypatch.setattr(
+        "cb_mcp.tools.diagnostics.get_pools_default_rest",
+        lambda **_: {},
+    )
+    result = get_cluster_stats(CTX)
+    assert result["node_count"] == 0
+    assert result["healthy_nodes"] == 0
+
+
+# --------------------------------------------------------------------------
+# get_node_info
+# --------------------------------------------------------------------------
+
+
+def test_get_node_info(monkeypatch):
+    monkeypatch.setattr(
+        "cb_mcp.tools.diagnostics.get_node_self_rest",
+        lambda **_: {"hostname": "node1:8091", "uptime": 12345},
+    )
+    result = get_node_info(CTX)
+    assert result == {"hostname": "node1:8091", "uptime": 12345}
+
+
+# --------------------------------------------------------------------------
+# get_bucket_stats
+# --------------------------------------------------------------------------
+
+
+def test_get_bucket_stats(monkeypatch):
+    captured = {}
+    monkeypatch.setattr(
+        "cb_mcp.tools.diagnostics.get_bucket_stats_rest",
+        lambda **kw: captured.update(kw) or {"op": {"samples": []}},
+    )
+    result = get_bucket_stats(CTX, bucket_name="travel-sample")
+    assert captured["bucket_name"] == "travel-sample"
+    assert result == {"op": {"samples": []}}
+
+
+# --------------------------------------------------------------------------
+# get_index_stats / get_query_stats / get_fts_stats
+# --------------------------------------------------------------------------
+
+
+def test_get_index_stats(monkeypatch):
+    monkeypatch.setattr(
+        "cb_mcp.tools.diagnostics.get_index_stats_rest",
+        lambda **_: {"indexer_ram_used": 12345},
+    )
+    result = get_index_stats(CTX)
+    assert result == {"indexer_ram_used": 12345}
+
+
+def test_get_query_stats(monkeypatch):
+    monkeypatch.setattr(
+        "cb_mcp.tools.diagnostics.get_query_stats_rest",
+        lambda **_: {"active_requests": 3},
+    )
+    result = get_query_stats(CTX)
+    assert result == {"active_requests": 3}
+
+
+def test_get_fts_stats(monkeypatch):
+    monkeypatch.setattr(
+        "cb_mcp.tools.diagnostics.get_fts_stats_rest",
+        lambda **_: {"num_indexes": 2},
+    )
+    result = get_fts_stats(CTX)
+    assert result == {"num_indexes": 2}
+
+
+# --------------------------------------------------------------------------
+# get_kv_stats
+# --------------------------------------------------------------------------
+
+
+def test_get_kv_stats(monkeypatch):
+    captured = {}
+    monkeypatch.setattr(
+        "cb_mcp.tools.diagnostics.get_kv_stats_rest",
+        lambda **kw: captured.update(kw) or {"curr_items": 12345},
+    )
+    result = get_kv_stats(CTX, bucket_name="travel-sample")
+    assert captured["bucket_name"] == "travel-sample"
+    assert result == {"curr_items": 12345}
+
+
+# --------------------------------------------------------------------------
+# get_disk_usage
+# --------------------------------------------------------------------------
+
+
+def test_get_disk_usage_extracts_storage_totals(monkeypatch):
+    monkeypatch.setattr(
+        "cb_mcp.tools.diagnostics.get_pools_default_rest",
+        lambda **_: {
+            "storageTotals": {
+                "ram": {"total": 1000, "used": 500},
+                "hdd": {"total": 10000, "usedByData": 2000},
+            }
+        },
+    )
+    result = get_disk_usage(CTX)
+    assert result == {
+        "ram": {"total": 1000, "used": 500},
+        "hdd": {"total": 10000, "usedByData": 2000},
+    }
+
+
+def test_get_disk_usage_handles_empty(monkeypatch):
+    monkeypatch.setattr(
+        "cb_mcp.tools.diagnostics.get_pools_default_rest",
+        lambda **_: {},
+    )
+    result = get_disk_usage(CTX)
+    assert result == {"ram": {}, "hdd": {}}
+
+
+# --------------------------------------------------------------------------
+# get_slow_queries
+# --------------------------------------------------------------------------
+
+
+def test_get_slow_queries_constructs_expected_statement(monkeypatch):
+    captured = {}
+
+    def _run(ctx, stmt, **_kw):
+        captured["stmt"] = stmt
+        return [{"requestId": "abc", "elapsedTime": "1.5s"}]
+
+    monkeypatch.setattr("cb_mcp.tools.diagnostics.run_cluster_query", _run)
+    result = get_slow_queries(CTX, min_duration_ms=500, limit=10)
+    assert "FROM system:completed_requests" in captured["stmt"]
+    assert "STR_TO_DURATION(elapsedTime)/1000000 >= 500" in captured["stmt"]
+    assert "LIMIT 10" in captured["stmt"]
+    assert result["min_duration_ms"] == 500
+    assert result["count"] == 1
+
+
+def test_get_slow_queries_defaults():
+    """Default min_duration=1000ms, limit=50."""
+    sig = inspect.signature(get_slow_queries)
+    assert sig.parameters["min_duration_ms"].default == 1000
+    assert sig.parameters["limit"].default == 50
+
+
+def test_get_slow_queries_rejects_negative_duration():
+    with pytest.raises(ValueError, match="cannot be negative"):
+        get_slow_queries(CTX, min_duration_ms=-100)
+
+
+def test_get_slow_queries_rejects_bad_limit():
+    with pytest.raises(ValueError, match="limit must be"):
+        get_slow_queries(CTX, limit=0)
+    with pytest.raises(ValueError, match="limit must be"):
+        get_slow_queries(CTX, limit=1001)
+
+
+# --------------------------------------------------------------------------
+# get_error_logs
+# --------------------------------------------------------------------------
+
+
+def test_get_error_logs(monkeypatch):
+    monkeypatch.setattr(
+        "cb_mcp.tools.diagnostics.get_error_logs_rest",
+        lambda **_: {"list": [{"text": "startup ok"}]},
+    )
+    result = get_error_logs(CTX)
+    assert result == {"list": [{"text": "startup ok"}]}
+
+
+# --------------------------------------------------------------------------
+# REST layer URL construction
+# --------------------------------------------------------------------------
+
+
+def test_pools_default_url(monkeypatch):
+    ctx_mgr, client = _stub_httpx_client()
+    monkeypatch.setattr(diagnostics_rest.httpx, "Client", lambda **_: ctx_mgr)
+
+    diagnostics_rest.get_pools_default_rest(
+        connection_string="couchbase://localhost",
+        username="u",
+        password="p",
+    )
+    url = client.get.call_args.args[0]
+    assert url.endswith("/pools/default")
+    assert ":8091/" in url
+
+
+def test_pools_default_tls_uses_18091(monkeypatch):
+    ctx_mgr, client = _stub_httpx_client()
+    monkeypatch.setattr(diagnostics_rest.httpx, "Client", lambda **_: ctx_mgr)
+
+    diagnostics_rest.get_pools_default_rest(
+        connection_string="couchbases://mycluster",
+        username="u",
+        password="p",
+    )
+    url = client.get.call_args.args[0]
+    assert url.startswith("https://")
+    assert ":18091/" in url
+
+
+def test_node_self_url(monkeypatch):
+    ctx_mgr, client = _stub_httpx_client()
+    monkeypatch.setattr(diagnostics_rest.httpx, "Client", lambda **_: ctx_mgr)
+
+    diagnostics_rest.get_node_self_rest(
+        connection_string="couchbase://localhost",
+        username="u",
+        password="p",
+    )
+    url = client.get.call_args.args[0]
+    assert url.endswith("/nodes/self")
+
+
+def test_bucket_stats_url_uses_encoding(monkeypatch):
+    ctx_mgr, client = _stub_httpx_client()
+    monkeypatch.setattr(diagnostics_rest.httpx, "Client", lambda **_: ctx_mgr)
+
+    diagnostics_rest.get_bucket_stats_rest(
+        connection_string="couchbase://localhost",
+        username="u",
+        password="p",
+        bucket_name="travel-sample",
+    )
+    url = client.get.call_args.args[0]
+    assert url.endswith("/pools/default/buckets/travel-sample/stats")
+
+
+def test_bucket_stats_rejects_bad_bucket_name():
+    with pytest.raises(ValueError, match="Invalid bucket name"):
+        diagnostics_rest.get_bucket_stats_rest(
+            connection_string="couchbase://localhost",
+            username="u",
+            password="p",
+            bucket_name="bad/name",
+        )
+
+
+def test_index_stats_url(monkeypatch):
+    ctx_mgr, client = _stub_httpx_client()
+    monkeypatch.setattr(diagnostics_rest.httpx, "Client", lambda **_: ctx_mgr)
+
+    diagnostics_rest.get_index_stats_rest(
+        connection_string="couchbase://localhost",
+        username="u",
+        password="p",
+    )
+    url = client.get.call_args.args[0]
+    assert url.endswith("/pools/default/buckets/@index/stats")
+
+
+def test_query_stats_url(monkeypatch):
+    ctx_mgr, client = _stub_httpx_client()
+    monkeypatch.setattr(diagnostics_rest.httpx, "Client", lambda **_: ctx_mgr)
+
+    diagnostics_rest.get_query_stats_rest(
+        connection_string="couchbase://localhost",
+        username="u",
+        password="p",
+    )
+    url = client.get.call_args.args[0]
+    assert url.endswith("/pools/default/buckets/@query/stats")
+
+
+def test_fts_stats_uses_fts_port_8094(monkeypatch):
+    ctx_mgr, client = _stub_httpx_client()
+    monkeypatch.setattr(diagnostics_rest.httpx, "Client", lambda **_: ctx_mgr)
+
+    diagnostics_rest.get_fts_stats_rest(
+        connection_string="couchbase://localhost",
+        username="u",
+        password="p",
+    )
+    url = client.get.call_args.args[0]
+    assert url.endswith("/api/nsstats")
+    assert ":8094/" in url
+
+
+def test_fts_stats_tls_uses_18094(monkeypatch):
+    ctx_mgr, client = _stub_httpx_client()
+    monkeypatch.setattr(diagnostics_rest.httpx, "Client", lambda **_: ctx_mgr)
+
+    diagnostics_rest.get_fts_stats_rest(
+        connection_string="couchbases://mycluster",
+        username="u",
+        password="p",
+    )
+    url = client.get.call_args.args[0]
+    assert url.startswith("https://")
+    assert ":18094/" in url
+
+
+def test_logs_url(monkeypatch):
+    ctx_mgr, client = _stub_httpx_client()
+    monkeypatch.setattr(diagnostics_rest.httpx, "Client", lambda **_: ctx_mgr)
+
+    diagnostics_rest.get_error_logs_rest(
+        connection_string="couchbase://localhost",
+        username="u",
+        password="p",
+    )
+    url = client.get.call_args.args[0]
+    assert url.endswith("/logs")

--- a/tests/unit/test_fts_admin.py
+++ b/tests/unit/test_fts_admin.py
@@ -1,0 +1,487 @@
+"""
+Unit tests for the FTS admin tool bodies (parameter validation,
+argument construction, confirmation gates, and write-scope gating),
+exercised against stubbed REST helpers so no live Couchbase cluster is
+required.
+
+License: MIT - Copyright (c) 2026 Chris Ahrendt
+"""
+
+import json
+from contextlib import contextmanager
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from cb_mcp.tools.fts_admin import (
+    _require_write_scope,
+    analyze_document,
+    create_fts_index,
+    delete_fts_index,
+    get_fts_index,
+    get_fts_index_count,
+    list_fts_indexes,
+    pause_fts_index_ingest,
+    resume_fts_index_ingest,
+    set_fts_index_query_control,
+    update_fts_index,
+)
+from cb_mcp.utils import fts_rest
+from cb_mcp.utils.constants import SCOPE_WRITE
+from cb_mcp.utils.fts_rest import (
+    ALLOWED_INGEST_OPS,
+    ALLOWED_QUERY_OPS,
+    _encode_path_segment,
+    assert_fts_index_name,
+)
+
+# --------------------------------------------------------------------------
+# Fixtures / helpers
+# --------------------------------------------------------------------------
+
+
+@contextmanager
+def _mock_token(scopes):
+    class _Tok:
+        def __init__(self, scopes_):
+            self.scopes = scopes_
+
+    token = _Tok(scopes) if scopes is not None else None
+    with patch("cb_mcp.tools.fts_admin.get_access_token", return_value=token):
+        yield
+
+
+def _ctx():
+    settings = {
+        "connection_string": "couchbase://localhost",
+        "username": "Administrator",
+        "password": "password",
+        "ca_cert_path": None,
+    }
+    lifespan = SimpleNamespace(settings=settings)
+    request = SimpleNamespace(lifespan_context=lifespan)
+    return SimpleNamespace(request_context=request)
+
+
+def _stub_httpx_client():
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.content = b'{"ok":true}'
+    resp.headers = {"content-type": "application/json"}
+    resp.json.return_value = {"ok": True}
+    resp.raise_for_status = MagicMock()
+
+    client = MagicMock()
+    client.get.return_value = resp
+    client.post.return_value = resp
+    client.put.return_value = resp
+    client.delete.return_value = resp
+
+    ctx_mgr = MagicMock()
+    ctx_mgr.__enter__.return_value = client
+    ctx_mgr.__exit__.return_value = False
+    return ctx_mgr, client
+
+
+CTX = _ctx()
+
+MIN_DEFINITION = {
+    "type": "fulltext-index",
+    "name": "will-be-replaced",
+    "sourceType": "couchbase",
+    "sourceName": "travel-sample",
+    "params": {},
+}
+
+
+# --------------------------------------------------------------------------
+# assert_fts_index_name
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "name",
+    ["idx-1", "hotel_index", "prod.v2", "A%B", "x" * 200],
+)
+def test_fts_index_name_valid(name):
+    assert_fts_index_name(name)
+
+
+@pytest.mark.parametrize(
+    "name",
+    ["", "x" * 201, "with/slash", "with space", "with\nnewline", None, 42],
+)
+def test_fts_index_name_invalid(name):
+    with pytest.raises(ValueError, match="Invalid FTS index name"):
+        assert_fts_index_name(name)  # type: ignore[arg-type]
+
+
+# --------------------------------------------------------------------------
+# _encode_path_segment
+# --------------------------------------------------------------------------
+
+
+def test_encode_path_segment_double_encodes_percent():
+    assert _encode_path_segment("%2f%2e%2e") == "%252f%252e%252e"
+
+
+def test_encode_path_segment_preserves_normal_names():
+    assert _encode_path_segment("hotel-index") == "hotel-index"
+
+
+# --------------------------------------------------------------------------
+# _require_write_scope
+# --------------------------------------------------------------------------
+
+
+def test_write_scope_noop_without_token():
+    with _mock_token(None):
+        _require_write_scope()
+
+
+def test_write_scope_raises_when_missing():
+    with _mock_token(["read"]), pytest.raises(PermissionError, match="write"):
+        _require_write_scope()
+
+
+def test_write_scope_passes_when_present():
+    with _mock_token(["read", SCOPE_WRITE]):
+        _require_write_scope()
+
+
+# --------------------------------------------------------------------------
+# Read tools
+# --------------------------------------------------------------------------
+
+
+def test_list_fts_indexes(monkeypatch):
+    monkeypatch.setattr(
+        "cb_mcp.tools.fts_admin.list_fts_indexes_rest",
+        lambda **_: {"indexDefs": {}, "status": "ok"},
+    )
+    result = list_fts_indexes(CTX)
+    assert result == {"indexDefs": {}, "status": "ok"}
+
+
+def test_get_fts_index(monkeypatch):
+    monkeypatch.setattr(
+        "cb_mcp.tools.fts_admin.get_fts_index_rest",
+        lambda **_: {"indexDef": {"name": "idx-1"}},
+    )
+    result = get_fts_index(CTX, index_name="idx-1")
+    assert result == {"indexDef": {"name": "idx-1"}}
+
+
+def test_get_fts_index_rejects_bad_name():
+    with pytest.raises(ValueError, match="Invalid FTS index name"):
+        get_fts_index(CTX, index_name="bad/name")
+
+
+def test_get_fts_index_count(monkeypatch):
+    monkeypatch.setattr(
+        "cb_mcp.tools.fts_admin.get_fts_index_count_rest",
+        lambda **_: {"count": 12345, "status": "ok"},
+    )
+    result = get_fts_index_count(CTX, index_name="idx-1")
+    assert result == {"count": 12345, "status": "ok"}
+
+
+def test_analyze_document(monkeypatch):
+    captured = {}
+    monkeypatch.setattr(
+        "cb_mcp.tools.fts_admin.analyze_doc_rest",
+        lambda **kw: captured.update(kw) or {"analyzed": []},
+    )
+    result = analyze_document(
+        CTX,
+        index_name="idx-1",
+        doc={"title": "Hello world"},
+    )
+    assert captured["doc"] == {"title": "Hello world"}
+    assert captured["index_name"] == "idx-1"
+    assert result == {"analyzed": []}
+
+
+def test_analyze_document_rejects_non_dict_doc():
+    with pytest.raises(ValueError, match="doc must be a dict"):
+        analyze_document(CTX, index_name="idx-1", doc="not a dict")  # type: ignore[arg-type]
+
+
+# --------------------------------------------------------------------------
+# create_fts_index
+# --------------------------------------------------------------------------
+
+
+def test_create_fts_index_normalizes_name(monkeypatch):
+    """The definition's 'name' field should be forced to match index_name."""
+    captured = {}
+    monkeypatch.setattr(
+        "cb_mcp.tools.fts_admin.create_or_update_fts_index_rest",
+        lambda **kw: captured.update(kw) or {},
+    )
+    with _mock_token(None):
+        result = create_fts_index(
+            CTX,
+            index_name="my-idx",
+            definition=dict(MIN_DEFINITION),
+        )
+    assert captured["definition"]["name"] == "my-idx"
+    assert result["index_name"] == "my-idx"
+
+
+def test_create_fts_index_rejects_non_dict_definition():
+    with (
+        _mock_token(None),
+        pytest.raises(ValueError, match="definition must be a dict"),
+    ):
+        create_fts_index(CTX, index_name="my-idx", definition="not a dict")  # type: ignore[arg-type]
+
+
+def test_create_fts_index_rejects_bad_name():
+    with _mock_token(None), pytest.raises(ValueError, match="Invalid FTS index name"):
+        create_fts_index(CTX, index_name="bad/name", definition=dict(MIN_DEFINITION))
+
+
+def test_create_fts_index_write_scope_required():
+    with _mock_token(["read"]), pytest.raises(PermissionError, match="write"):
+        create_fts_index(CTX, index_name="my-idx", definition=dict(MIN_DEFINITION))
+
+
+# --------------------------------------------------------------------------
+# update_fts_index
+# --------------------------------------------------------------------------
+
+
+def test_update_fts_index_uses_same_endpoint(monkeypatch):
+    """update_fts_index and create_fts_index both hit create_or_update_fts_index_rest."""
+    captured = {}
+    monkeypatch.setattr(
+        "cb_mcp.tools.fts_admin.create_or_update_fts_index_rest",
+        lambda **kw: captured.update(kw) or {},
+    )
+    with _mock_token(None):
+        update_fts_index(
+            CTX,
+            index_name="my-idx",
+            definition=dict(MIN_DEFINITION),
+        )
+    assert captured["index_name"] == "my-idx"
+    assert captured["definition"]["name"] == "my-idx"
+
+
+# --------------------------------------------------------------------------
+# delete_fts_index
+# --------------------------------------------------------------------------
+
+
+def test_delete_fts_index_requires_confirm_true():
+    with _mock_token(None), pytest.raises(ValueError, match="confirm=True"):
+        delete_fts_index(CTX, index_name="my-idx")
+
+
+def test_delete_fts_index_requires_matching_confirm_name():
+    with _mock_token(None), pytest.raises(ValueError, match="confirm_name"):
+        delete_fts_index(CTX, index_name="my-idx", confirm=True, confirm_name="wrong")
+
+
+def test_delete_fts_index_requires_confirm_name_explicitly():
+    with _mock_token(None), pytest.raises(ValueError, match="confirm_name"):
+        delete_fts_index(CTX, index_name="my-idx", confirm=True)
+
+
+def test_delete_fts_index_succeeds(monkeypatch):
+    monkeypatch.setattr(
+        "cb_mcp.tools.fts_admin.delete_fts_index_rest",
+        lambda **_: {"status": "ok"},
+    )
+    with _mock_token(None):
+        result = delete_fts_index(
+            CTX, index_name="my-idx", confirm=True, confirm_name="my-idx"
+        )
+    assert result == {
+        "index_name": "my-idx",
+        "deleted": True,
+        "result": {"status": "ok"},
+    }
+
+
+# --------------------------------------------------------------------------
+# pause_fts_index_ingest / resume_fts_index_ingest
+# --------------------------------------------------------------------------
+
+
+def test_pause_fts_index_ingest(monkeypatch):
+    captured = {}
+    monkeypatch.setattr(
+        "cb_mcp.tools.fts_admin.ingest_control_rest",
+        lambda **kw: captured.update(kw) or {},
+    )
+    with _mock_token(None):
+        result = pause_fts_index_ingest(CTX, index_name="my-idx")
+    assert captured["op"] == "pause"
+    assert result["ingest_paused"] is True
+
+
+def test_resume_fts_index_ingest(monkeypatch):
+    captured = {}
+    monkeypatch.setattr(
+        "cb_mcp.tools.fts_admin.ingest_control_rest",
+        lambda **kw: captured.update(kw) or {},
+    )
+    with _mock_token(None):
+        result = resume_fts_index_ingest(CTX, index_name="my-idx")
+    assert captured["op"] == "resume"
+    assert result["ingest_resumed"] is True
+
+
+# --------------------------------------------------------------------------
+# set_fts_index_query_control
+# --------------------------------------------------------------------------
+
+
+def test_set_fts_index_query_control_allow(monkeypatch):
+    captured = {}
+    monkeypatch.setattr(
+        "cb_mcp.tools.fts_admin.query_control_rest",
+        lambda **kw: captured.update(kw) or {},
+    )
+    with _mock_token(None):
+        result = set_fts_index_query_control(CTX, index_name="my-idx", allow=True)
+    assert captured["op"] == "allow"
+    assert result["queries_allowed"] is True
+
+
+def test_set_fts_index_query_control_disallow(monkeypatch):
+    captured = {}
+    monkeypatch.setattr(
+        "cb_mcp.tools.fts_admin.query_control_rest",
+        lambda **kw: captured.update(kw) or {},
+    )
+    with _mock_token(None):
+        result = set_fts_index_query_control(CTX, index_name="my-idx", allow=False)
+    assert captured["op"] == "disallow"
+    assert result["queries_allowed"] is False
+
+
+# --------------------------------------------------------------------------
+# Op allow-lists match between tool and REST
+# --------------------------------------------------------------------------
+
+
+def test_ingest_ops_allow_list():
+    assert frozenset({"pause", "resume"}) == ALLOWED_INGEST_OPS
+
+
+def test_query_ops_allow_list():
+    assert frozenset({"allow", "disallow"}) == ALLOWED_QUERY_OPS
+
+
+# --------------------------------------------------------------------------
+# REST layer URL construction (httpx stubbed)
+# --------------------------------------------------------------------------
+
+
+def test_get_index_url_and_port(monkeypatch):
+    ctx_mgr, client = _stub_httpx_client()
+    monkeypatch.setattr(fts_rest.httpx, "Client", lambda **_: ctx_mgr)
+
+    fts_rest.get_fts_index_rest(
+        connection_string="couchbase://localhost",
+        username="u",
+        password="p",
+        index_name="idx-1",
+    )
+    url = client.get.call_args.args[0]
+    assert url.endswith("/api/index/idx-1")
+    assert ":8094/" in url
+
+
+def test_tls_uses_18094(monkeypatch):
+    ctx_mgr, client = _stub_httpx_client()
+    monkeypatch.setattr(fts_rest.httpx, "Client", lambda **_: ctx_mgr)
+
+    fts_rest.get_fts_index_rest(
+        connection_string="couchbases://mycluster",
+        username="u",
+        password="p",
+        index_name="idx-1",
+    )
+    url = client.get.call_args.args[0]
+    assert url.startswith("https://")
+    assert ":18094/" in url
+
+
+def test_ingest_control_rest_url(monkeypatch):
+    ctx_mgr, client = _stub_httpx_client()
+    monkeypatch.setattr(fts_rest.httpx, "Client", lambda **_: ctx_mgr)
+
+    fts_rest.ingest_control_rest(
+        connection_string="couchbase://localhost",
+        username="u",
+        password="p",
+        index_name="idx-1",
+        op="pause",
+    )
+    url = client.post.call_args.args[0]
+    assert url.endswith("/api/index/idx-1/ingestControl/pause")
+
+
+def test_ingest_control_rest_rejects_bad_op():
+    with pytest.raises(ValueError, match="op must be"):
+        fts_rest.ingest_control_rest(
+            connection_string="couchbase://localhost",
+            username="u",
+            password="p",
+            index_name="idx-1",
+            op="stop",
+        )
+
+
+def test_query_control_rest_url(monkeypatch):
+    ctx_mgr, client = _stub_httpx_client()
+    monkeypatch.setattr(fts_rest.httpx, "Client", lambda **_: ctx_mgr)
+
+    fts_rest.query_control_rest(
+        connection_string="couchbase://localhost",
+        username="u",
+        password="p",
+        index_name="idx-1",
+        op="disallow",
+    )
+    url = client.post.call_args.args[0]
+    assert url.endswith("/api/index/idx-1/queryControl/disallow")
+
+
+def test_analyze_doc_rest_url_and_body(monkeypatch):
+    ctx_mgr, client = _stub_httpx_client()
+    monkeypatch.setattr(fts_rest.httpx, "Client", lambda **_: ctx_mgr)
+
+    fts_rest.analyze_doc_rest(
+        connection_string="couchbase://localhost",
+        username="u",
+        password="p",
+        index_name="idx-1",
+        doc={"title": "Hello"},
+    )
+    call_kwargs = client.post.call_args.kwargs
+    assert client.post.call_args.args[0].endswith("/api/analyzeDoc/idx-1")
+    assert json.loads(call_kwargs["content"]) == {"title": "Hello"}
+    assert call_kwargs["headers"]["Content-Type"] == "application/json"
+
+
+def test_create_index_uses_put(monkeypatch):
+    ctx_mgr, client = _stub_httpx_client()
+    monkeypatch.setattr(fts_rest.httpx, "Client", lambda **_: ctx_mgr)
+
+    fts_rest.create_or_update_fts_index_rest(
+        connection_string="couchbase://localhost",
+        username="u",
+        password="p",
+        index_name="idx-1",
+        definition={"type": "fulltext-index", "name": "idx-1"},
+    )
+    # Verify PUT was called, not POST
+    client.put.assert_called_once()
+    url = client.put.call_args.args[0]
+    assert url.endswith("/api/index/idx-1")

--- a/tests/unit/test_index_admin_tools_unit.py
+++ b/tests/unit/test_index_admin_tools_unit.py
@@ -1,0 +1,211 @@
+"""
+Unit tests for the index-management tool bodies (statement construction and
+write-scope gating), exercised against stubbed cluster and token modules so
+no live Couchbase cluster is required.
+
+License: MIT - Copyright (c) 2026 Chris Ahrendt
+"""
+
+from contextlib import contextmanager
+from unittest.mock import patch
+
+import pytest
+
+from cb_mcp.tools.index_admin import (
+    build_deferred_indexes,
+    create_index,
+    drop_index,
+)
+
+
+@contextmanager
+def _mock_token(scopes):
+    """Patch get_access_token at the index_admin call site.
+
+    Pass a list of scopes for an authenticated token, or None for no token
+    (stdio / OAuth disabled).
+    """
+
+    class _Tok:
+        def __init__(self, scopes_):
+            self.scopes = scopes_
+
+    token = _Tok(scopes) if scopes is not None else None
+    with patch("cb_mcp.tools.index_admin.get_access_token", return_value=token):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def _stub_cluster_query(monkeypatch):
+    """Patch run_cluster_query at the index_admin call site so statement
+    construction can be tested without a live cluster. Records nothing;
+    tests assert on the returned ``statement`` field the tool echoes back."""
+    monkeypatch.setattr(
+        "cb_mcp.tools.index_admin.run_cluster_query",
+        lambda ctx, statement, **kw: [{"ok": True}],
+    )
+    yield
+
+
+CTX = object()  # tools never introspect ctx directly; they pass it through
+
+
+# --------------------------------------------------------------------------
+# create_index - structured path
+# --------------------------------------------------------------------------
+
+
+def test_create_secondary_index_builds_expected_statement():
+    out = create_index(
+        CTX,
+        index_name="idx_name",
+        bucket_name="travel-sample",
+        scope_name="inventory",
+        collection_name="airline",
+        fields=["name", "country"],
+    )
+    assert out["statement"] == (
+        "CREATE INDEX `idx_name` ON "
+        "`travel-sample`.`inventory`.`airline` (`name`, `country`)"
+    )
+
+
+def test_create_primary_index_with_name():
+    out = create_index(CTX, index_name="pk", bucket_name="b", is_primary=True)
+    assert out["statement"] == "CREATE PRIMARY INDEX `pk` ON `b`.`_default`.`_default`"
+
+
+def test_create_primary_index_without_name():
+    out = create_index(CTX, bucket_name="b", is_primary=True)
+    assert out["statement"] == "CREATE PRIMARY INDEX ON `b`.`_default`.`_default`"
+
+
+def test_create_with_num_replica_and_defer():
+    out = create_index(
+        CTX,
+        index_name="i",
+        bucket_name="b",
+        fields=["x"],
+        num_replica=2,
+        defer_build=True,
+    )
+    assert out["statement"].endswith('WITH {"num_replica": 2, "defer_build": true}')
+
+
+def test_create_missing_bucket_raises():
+    with pytest.raises(ValueError, match="bucket_name is required"):
+        create_index(CTX, index_name="i", fields=["x"])
+
+
+def test_create_secondary_missing_fields_raises():
+    with pytest.raises(ValueError, match="fields are required"):
+        create_index(CTX, index_name="i", bucket_name="b")
+
+
+def test_create_secondary_missing_name_raises():
+    with pytest.raises(ValueError, match="index_name is required"):
+        create_index(CTX, bucket_name="b", fields=["x"])
+
+
+# --------------------------------------------------------------------------
+# create_index - raw statement path
+# --------------------------------------------------------------------------
+
+
+def test_create_raw_statement_allowed():
+    out = create_index(CTX, statement="CREATE INDEX i ON b.s.c (x)")
+    assert out["statement"] == "CREATE INDEX i ON b.s.c (x)"
+
+
+def test_create_raw_statement_rejected():
+    with pytest.raises(ValueError, match="index-create DDL"):
+        create_index(CTX, statement="DELETE FROM b.s.c")
+
+
+# --------------------------------------------------------------------------
+# drop_index
+# --------------------------------------------------------------------------
+
+
+def test_drop_secondary_index_statement():
+    out = drop_index(
+        CTX, index_name="i", bucket_name="b", scope_name="s", collection_name="c"
+    )
+    assert out["statement"] == "DROP INDEX `i` ON `b`.`s`.`c`"
+
+
+def test_drop_primary_index_statement():
+    out = drop_index(CTX, bucket_name="b", is_primary=True)
+    assert out["statement"] == "DROP PRIMARY INDEX ON `b`.`_default`.`_default`"
+
+
+def test_drop_raw_statement_rejected():
+    with pytest.raises(ValueError, match="DROP INDEX"):
+        drop_index(CTX, statement="DROP SCOPE b.s")
+
+
+def test_drop_missing_name_raises():
+    with pytest.raises(ValueError, match="index_name is required"):
+        drop_index(CTX, bucket_name="b")
+
+
+# --------------------------------------------------------------------------
+# build_deferred_indexes
+# --------------------------------------------------------------------------
+
+
+def test_build_bucket_level():
+    out = build_deferred_indexes(CTX, bucket_name="b", index_names=["i1", "i2"])
+    assert out["statement"] == "BUILD INDEX ON `b` (`i1`, `i2`)"
+
+
+def test_build_collection_level():
+    out = build_deferred_indexes(
+        CTX,
+        bucket_name="b",
+        index_names=["i1"],
+        scope_name="s",
+        collection_name="c",
+    )
+    assert out["statement"] == "BUILD INDEX ON `b`.`s`.`c` (`i1`)"
+
+
+def test_build_partial_keyspace_raises():
+    with pytest.raises(ValueError, match="must be provided together"):
+        build_deferred_indexes(CTX, bucket_name="b", index_names=["i"], scope_name="s")
+
+
+def test_build_empty_names_raises():
+    with pytest.raises(ValueError, match="at least one"):
+        build_deferred_indexes(CTX, bucket_name="b", index_names=[])
+
+
+# --------------------------------------------------------------------------
+# write-scope gating (mirrors run_sql_plus_plus_query semantics)
+# --------------------------------------------------------------------------
+
+
+def test_no_token_allows_write():
+    # stdio / OAuth disabled: no token in context -> no scope enforcement
+    with _mock_token(None):
+        out = create_index(CTX, bucket_name="b", is_primary=True)
+    assert out["statement"].startswith("CREATE PRIMARY INDEX")
+
+
+def test_token_with_write_scope_allows():
+    with _mock_token(["couchbase-mcp:write"]):
+        out = drop_index(CTX, bucket_name="b", is_primary=True)
+    assert out["statement"].startswith("DROP PRIMARY INDEX")
+
+
+def test_token_without_write_scope_denied():
+    with (
+        _mock_token(["couchbase-mcp:read"]),
+        pytest.raises(PermissionError, match="requires the 'couchbase-mcp:write'"),
+    ):
+        create_index(CTX, bucket_name="b", is_primary=True)
+
+
+def test_build_denied_without_write_scope():
+    with _mock_token([]), pytest.raises(PermissionError):
+        build_deferred_indexes(CTX, bucket_name="b", index_names=["i"])

--- a/tests/unit/test_index_ddl_unit.py
+++ b/tests/unit/test_index_ddl_unit.py
@@ -1,0 +1,151 @@
+"""
+Unit tests for index DDL safety primitives and statement construction.
+
+These run without a Couchbase cluster: they exercise the pure logic
+(identifier quoting, statement allow-listing, statement building) and the
+write-scope check via a stubbed access token. The cluster execution path
+(``run_cluster_query``) is monkeypatched.
+
+License: MIT - Copyright (c) 2026 Chris Ahrendt
+"""
+
+import pytest
+
+from cb_mcp.utils.index_ddl import (
+    assert_index_create_ddl,
+    assert_index_drop_ddl,
+    safe_ident,
+)
+
+# --------------------------------------------------------------------------
+# safe_ident
+# --------------------------------------------------------------------------
+
+
+def test_safe_ident_wraps_in_backticks():
+    assert safe_ident("users") == "`users`"
+
+
+def test_safe_ident_doubles_embedded_backtick():
+    # A name containing a backtick must not be able to terminate its quoting.
+    assert safe_ident("we`ird") == "`we``ird`"
+
+
+def test_safe_ident_handles_empty_and_none():
+    assert safe_ident("") == "``"
+    assert safe_ident(None) == "``"
+
+
+def test_safe_ident_injection_attempt_is_neutralized():
+    # Attempt to break out and append a DROP; the backtick is doubled so the
+    # whole thing stays a single (absurd) identifier.
+    malicious = "x` ON b.s.c; DROP INDEX `y"
+    quoted = safe_ident(malicious)
+    assert quoted.startswith("`") and quoted.endswith("`")
+    # No unescaped backtick remains that could close the identifier early.
+    inner = quoted[1:-1]
+    assert "``" in inner
+    assert not any(
+        inner[i] == "`" and inner[i - 1] != "`" and inner[i + 1 : i + 2] != "`"
+        for i in range(1, len(inner) - 1)
+    )
+
+
+# --------------------------------------------------------------------------
+# assert_index_create_ddl
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "stmt",
+    [
+        "CREATE INDEX idx ON b.s.c (name)",
+        "create index idx on b.s.c (name)",
+        "CREATE PRIMARY INDEX ON b.s.c",
+        "  CREATE   PRIMARY   INDEX ON b.s.c",
+        "CREATE VECTOR INDEX v ON b.s.c (emb VECTOR)",
+        "CREATE HYPERSCALE VECTOR INDEX v ON b.s.c (emb VECTOR)",
+        "CREATE COMPOSITE VECTOR INDEX v ON b.s.c (emb VECTOR)",
+    ],
+)
+def test_create_ddl_allows_index_statements(stmt):
+    assert assert_index_create_ddl(stmt) is None
+
+
+@pytest.mark.parametrize(
+    "stmt",
+    [
+        "SELECT * FROM b.s.c",
+        "DELETE FROM b.s.c",
+        "UPDATE b.s.c SET x = 1",
+        "DROP INDEX idx ON b.s.c",
+        "INSERT INTO b.s.c VALUES (1, {})",
+        "CREATE SCOPE b.s",
+        "CREATE COLLECTION b.s.c",
+        "",
+        "   ",
+        "; CREATE INDEX idx ON b.s.c (name)",  # leading junk before keyword
+        "BUILD INDEX ON b.s.c (i)",  # BUILD routes to build_deferred_indexes
+        # multi-statement injection: permitted head + smuggled tail
+        "CREATE INDEX i ON b.s.c (x); DELETE FROM b.s.c WHERE 1=1",
+        "CREATE PRIMARY INDEX ON b.s.c ; DROP SCOPE b.s",
+        "CREATE INDEX i ON b.s.c (x);SELECT 1",
+    ],
+)
+def test_create_ddl_rejects_non_index_statements(stmt):
+    msg = assert_index_create_ddl(stmt)
+    assert msg is not None
+    assert "index-create DDL" in msg
+
+
+def test_create_ddl_handles_none():
+    assert assert_index_create_ddl(None) is not None
+
+
+@pytest.mark.parametrize(
+    "stmt",
+    [
+        "CREATE INDEX i ON b.s.c (name);",  # single trailing semicolon
+        "CREATE INDEX i ON b.s.c (name)  ;  ",  # trailing semicolon + whitespace
+        "CREATE INDEX `weird;name` ON b.s.c (x)",  # ';' inside a quoted ident
+    ],
+)
+def test_create_ddl_allows_trailing_semicolon_and_quoted_semicolon(stmt):
+    assert assert_index_create_ddl(stmt) is None
+
+
+# --------------------------------------------------------------------------
+# assert_index_drop_ddl
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "stmt",
+    [
+        "DROP INDEX idx ON b.s.c",
+        "drop index idx on b.s.c",
+        "DROP PRIMARY INDEX ON b.s.c",
+        "DROP VECTOR INDEX v ON b.s.c",
+        "  DROP   INDEX idx ON b.s.c",
+    ],
+)
+def test_drop_ddl_allows_drop_statements(stmt):
+    assert assert_index_drop_ddl(stmt) is None
+
+
+@pytest.mark.parametrize(
+    "stmt",
+    [
+        "CREATE INDEX idx ON b.s.c (name)",
+        "SELECT * FROM b.s.c",
+        "DELETE FROM b.s.c",
+        "DROP SCOPE b.s",
+        "DROP COLLECTION b.s.c",
+        "DROP PRIMARY VECTOR INDEX ON b.s.c",  # not a real statement shape
+        "DROP INDEX i ON b.s.c; CREATE PRIMARY INDEX ON b.s.c",  # injection
+        "",
+        None,
+    ],
+)
+def test_drop_ddl_rejects_non_drop_statements(stmt):
+    assert assert_index_drop_ddl(stmt) is not None

--- a/tests/unit/test_index_settings_unit.py
+++ b/tests/unit/test_index_settings_unit.py
@@ -1,0 +1,186 @@
+"""
+Unit tests for the GSI settings tools and REST helper pure logic.
+
+The tools' network calls (get_gsi_settings / set_gsi_settings) are
+monkeypatched so these tests exercise parameter mapping and gating without a
+cluster. The REST helper's pure functions (_form_value, _settings_base) are
+tested directly.
+
+License: MIT - Copyright (c) 2026 Chris Ahrendt
+"""
+
+from contextlib import contextmanager
+from unittest.mock import patch
+
+import pytest
+
+from cb_mcp.tools import index_admin
+from cb_mcp.utils import index_settings
+
+
+@contextmanager
+def _mock_token(scopes):
+    class _Tok:
+        def __init__(self, scopes_):
+            self.scopes = scopes_
+
+    token = _Tok(scopes) if scopes is not None else None
+    with patch("cb_mcp.tools.index_admin.get_access_token", return_value=token):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def _stub_get_settings(monkeypatch):
+    """Patch get_settings so settings tools don't require a live AppContext."""
+    monkeypatch.setattr(
+        "cb_mcp.tools.index_admin.get_settings",
+        lambda ctx: {
+            "connection_string": "couchbase://localhost",
+            "username": "u",
+            "password": "p",
+            "ca_cert_path": None,
+        },
+    )
+    yield
+
+
+CTX = object()
+
+
+# --------------------------------------------------------------------------
+# REST helper pure logic
+# --------------------------------------------------------------------------
+
+
+def test_form_value_bools_lowercased():
+    assert index_settings._form_value(True) == "true"
+    assert index_settings._form_value(False) == "false"
+
+
+def test_form_value_ints_and_strings():
+    assert index_settings._form_value(4) == "4"
+    assert index_settings._form_value("plasma") == "plasma"
+
+
+def test_settings_base_non_tls():
+    assert index_settings._settings_base("couchbase://localhost") == ("http", 8091)
+
+
+def test_settings_base_tls():
+    assert index_settings._settings_base("couchbases://cb.example") == (
+        "https",
+        18091,
+    )
+
+
+def test_set_gsi_settings_rejects_empty():
+    with pytest.raises(ValueError, match="at least one setting"):
+        index_settings.set_gsi_settings("couchbase://h", "u", "p", params={})
+
+
+def test_set_gsi_settings_rejects_all_none():
+    with pytest.raises(ValueError, match="no non-null settings"):
+        index_settings.set_gsi_settings(
+            "couchbase://h", "u", "p", params={"numReplica": None}
+        )
+
+
+# --------------------------------------------------------------------------
+# admin_index_settings_get
+# --------------------------------------------------------------------------
+
+
+def test_settings_get_returns_settings(monkeypatch):
+    captured = {}
+
+    def fake_get(**kwargs):
+        captured.update(kwargs)
+        return {"indexerThreads": 4, "logLevel": "info"}
+
+    monkeypatch.setattr(index_admin, "get_gsi_settings", fake_get)
+    out = index_admin.admin_index_settings_get(CTX)
+    assert out == {"indexerThreads": 4, "logLevel": "info"}
+    assert captured["connection_string"] == "couchbase://localhost"
+
+
+# --------------------------------------------------------------------------
+# admin_index_settings_set - param mapping
+# --------------------------------------------------------------------------
+
+
+def test_settings_set_maps_named_params(monkeypatch):
+    captured = {}
+
+    def fake_set(**kwargs):
+        captured.update(kwargs)
+        return {"applied": True}
+
+    monkeypatch.setattr(index_admin, "set_gsi_settings", fake_set)
+    index_admin.admin_index_settings_set(
+        CTX,
+        indexer_threads=8,
+        log_level="verbose",
+        redistribute_indexes=False,
+    )
+    assert captured["params"] == {
+        "indexerThreads": 8,
+        "logLevel": "verbose",
+        "redistributeIndexes": False,
+    }
+
+
+def test_settings_set_merges_extra(monkeypatch):
+    captured = {}
+    monkeypatch.setattr(
+        index_admin,
+        "set_gsi_settings",
+        lambda **kw: captured.update(kw) or {},
+    )
+    # extra keys must be documented camelCase GSI keys; enableShardAffinity is
+    # valid but has no named parameter in an older tool version, so it is a
+    # representative forward-compat use of the escape hatch.
+    index_admin.admin_index_settings_set(
+        CTX, num_replica=2, extra={"enableShardAffinity": True}
+    )
+    assert captured["params"] == {"numReplica": 2, "enableShardAffinity": True}
+
+
+def test_settings_set_rejects_unknown_extra_key(monkeypatch):
+    monkeypatch.setattr(index_admin, "set_gsi_settings", lambda **kw: {})
+    with pytest.raises(ValueError, match="Unknown GSI setting key"):
+        index_admin.admin_index_settings_set(CTX, extra={"arbitraryKey": "x"})
+
+
+def test_settings_set_requires_at_least_one(monkeypatch):
+    monkeypatch.setattr(index_admin, "set_gsi_settings", lambda **kw: {})
+    with pytest.raises(ValueError, match="at least one setting"):
+        index_admin.admin_index_settings_set(CTX)
+
+
+def test_settings_set_omits_none_values(monkeypatch):
+    captured = {}
+    monkeypatch.setattr(
+        index_admin,
+        "set_gsi_settings",
+        lambda **kw: captured.update(kw) or {},
+    )
+    index_admin.admin_index_settings_set(CTX, storage_mode="plasma")
+    assert captured["params"] == {"storageMode": "plasma"}
+
+
+# --------------------------------------------------------------------------
+# write-scope gating on set (get is read-only, not gated)
+# --------------------------------------------------------------------------
+
+
+def test_settings_set_denied_without_write_scope(monkeypatch):
+    monkeypatch.setattr(index_admin, "set_gsi_settings", lambda **kw: {})
+    with _mock_token(["couchbase-mcp:read"]), pytest.raises(PermissionError):
+        index_admin.admin_index_settings_set(CTX, indexer_threads=4)
+
+
+def test_settings_set_allowed_with_write_scope(monkeypatch):
+    monkeypatch.setattr(index_admin, "set_gsi_settings", lambda **kw: {"ok": True})
+    with _mock_token(["couchbase-mcp:write"]):
+        out = index_admin.admin_index_settings_set(CTX, indexer_threads=4)
+    assert out == {"ok": True}

--- a/tests/unit/test_read_only_mode.py
+++ b/tests/unit/test_read_only_mode.py
@@ -24,7 +24,7 @@ KV_WRITE_TOOL_NAMES = {
     "delete_document_by_id",
 }
 
-# Read-only tool names that should always be available (20 tools)
+# Read-only tool names that should always be available (21 tools)
 READ_ONLY_TOOL_NAMES = {
     # Server/Cluster management tools (7)
     "get_buckets_in_cluster",
@@ -43,6 +43,8 @@ READ_ONLY_TOOL_NAMES = {
     # Index tools (2)
     "get_index_advisor_recommendations",
     "list_indexes",
+    # Index settings read tool (1)
+    "admin_index_settings_get",
     # Query performance analysis tools (7)
     "get_queries_not_selective",
     "get_queries_not_using_covering_index",
@@ -157,13 +159,13 @@ class TestToolCounts:
         """Verify correct number of tools in read-only mode."""
         tools = get_tools(read_only_mode=True)
         assert len(tools) == len(READ_ONLY_TOOLS)
-        assert len(tools) == 20  # Expected count of read-only tools
+        assert len(tools) == 21  # Expected count of read-only tools
 
     def test_all_tools_mode_tool_count(self):
         """Verify correct number of tools when all write tools are enabled."""
         tools = get_tools(read_only_mode=False)
         assert len(tools) == len(ALL_TOOLS)
-        assert len(tools) == 24  # Expected total count (20 read-only + 4 KV write)
+        assert len(tools) == 25  # Expected total count (21 read-only + 4 KV write)
 
     def test_kv_write_tools_count(self):
         """Verify exactly 4 KV write tools exist."""

--- a/tests/unit/test_read_only_mode.py
+++ b/tests/unit/test_read_only_mode.py
@@ -24,7 +24,7 @@ KV_WRITE_TOOL_NAMES = {
     "delete_document_by_id",
 }
 
-# Read-only tool names that should always be available (21 tools)
+# Read-only tool names that should always be available (22 tools)
 READ_ONLY_TOOL_NAMES = {
     # Server/Cluster management tools (7)
     "get_buckets_in_cluster",
@@ -45,6 +45,8 @@ READ_ONLY_TOOL_NAMES = {
     "list_indexes",
     # Index settings read tool (1)
     "admin_index_settings_get",
+    # Collection settings read tool (1)
+    "get_collection_settings",
     # Query performance analysis tools (7)
     "get_queries_not_selective",
     "get_queries_not_using_covering_index",
@@ -159,13 +161,13 @@ class TestToolCounts:
         """Verify correct number of tools in read-only mode."""
         tools = get_tools(read_only_mode=True)
         assert len(tools) == len(READ_ONLY_TOOLS)
-        assert len(tools) == 21  # Expected count of read-only tools
+        assert len(tools) == 22  # Expected count of read-only tools
 
     def test_all_tools_mode_tool_count(self):
         """Verify correct number of tools when all write tools are enabled."""
         tools = get_tools(read_only_mode=False)
         assert len(tools) == len(ALL_TOOLS)
-        assert len(tools) == 25  # Expected total count (21 read-only + 4 KV write)
+        assert len(tools) == 26  # Expected total count (22 read-only + 4 KV write)
 
     def test_kv_write_tools_count(self):
         """Verify exactly 4 KV write tools exist."""

--- a/tests/unit/test_read_only_mode.py
+++ b/tests/unit/test_read_only_mode.py
@@ -24,7 +24,7 @@ KV_WRITE_TOOL_NAMES = {
     "delete_document_by_id",
 }
 
-# Read-only tool names that should always be available (25 tools)
+# Read-only tool names that should always be available (29 tools)
 READ_ONLY_TOOL_NAMES = {
     # Server/Cluster management tools (7)
     "get_buckets_in_cluster",
@@ -51,6 +51,11 @@ READ_ONLY_TOOL_NAMES = {
     "list_remote_clusters",
     "list_replications",
     "get_replication_settings",
+    # FTS read tools (4)
+    "list_fts_indexes",
+    "get_fts_index",
+    "get_fts_index_count",
+    "analyze_document",
     # Query performance analysis tools (7)
     "get_queries_not_selective",
     "get_queries_not_using_covering_index",
@@ -165,13 +170,13 @@ class TestToolCounts:
         """Verify correct number of tools in read-only mode."""
         tools = get_tools(read_only_mode=True)
         assert len(tools) == len(READ_ONLY_TOOLS)
-        assert len(tools) == 25  # Expected count of read-only tools
+        assert len(tools) == 29  # Expected count of read-only tools
 
     def test_all_tools_mode_tool_count(self):
         """Verify correct number of tools when all write tools are enabled."""
         tools = get_tools(read_only_mode=False)
         assert len(tools) == len(ALL_TOOLS)
-        assert len(tools) == 29  # Expected total count (25 read-only + 4 KV write)
+        assert len(tools) == 33  # Expected total count (29 read-only + 4 KV write)
 
     def test_kv_write_tools_count(self):
         """Verify exactly 4 KV write tools exist."""

--- a/tests/unit/test_read_only_mode.py
+++ b/tests/unit/test_read_only_mode.py
@@ -24,7 +24,7 @@ KV_WRITE_TOOL_NAMES = {
     "delete_document_by_id",
 }
 
-# Read-only tool names that should always be available (22 tools)
+# Read-only tool names that should always be available (25 tools)
 READ_ONLY_TOOL_NAMES = {
     # Server/Cluster management tools (7)
     "get_buckets_in_cluster",
@@ -47,6 +47,10 @@ READ_ONLY_TOOL_NAMES = {
     "admin_index_settings_get",
     # Collection settings read tool (1)
     "get_collection_settings",
+    # XDCR read tools (3)
+    "list_remote_clusters",
+    "list_replications",
+    "get_replication_settings",
     # Query performance analysis tools (7)
     "get_queries_not_selective",
     "get_queries_not_using_covering_index",
@@ -161,13 +165,13 @@ class TestToolCounts:
         """Verify correct number of tools in read-only mode."""
         tools = get_tools(read_only_mode=True)
         assert len(tools) == len(READ_ONLY_TOOLS)
-        assert len(tools) == 22  # Expected count of read-only tools
+        assert len(tools) == 25  # Expected count of read-only tools
 
     def test_all_tools_mode_tool_count(self):
         """Verify correct number of tools when all write tools are enabled."""
         tools = get_tools(read_only_mode=False)
         assert len(tools) == len(ALL_TOOLS)
-        assert len(tools) == 26  # Expected total count (22 read-only + 4 KV write)
+        assert len(tools) == 29  # Expected total count (25 read-only + 4 KV write)
 
     def test_kv_write_tools_count(self):
         """Verify exactly 4 KV write tools exist."""

--- a/tests/unit/test_read_only_mode.py
+++ b/tests/unit/test_read_only_mode.py
@@ -24,7 +24,7 @@ KV_WRITE_TOOL_NAMES = {
     "delete_document_by_id",
 }
 
-# Read-only tool names that should always be available (29 tools)
+# Read-only tool names that should always be available (38 tools)
 READ_ONLY_TOOL_NAMES = {
     # Server/Cluster management tools (7)
     "get_buckets_in_cluster",
@@ -56,6 +56,16 @@ READ_ONLY_TOOL_NAMES = {
     "get_fts_index",
     "get_fts_index_count",
     "analyze_document",
+    # Diagnostics read tools (9)
+    "get_cluster_info",
+    "get_cluster_stats",
+    "get_node_info",
+    "get_bucket_stats",
+    "get_index_stats",
+    "get_query_stats",
+    "get_fts_stats",
+    "get_kv_stats",
+    "get_disk_usage",
     # Query performance analysis tools (7)
     "get_queries_not_selective",
     "get_queries_not_using_covering_index",
@@ -170,13 +180,13 @@ class TestToolCounts:
         """Verify correct number of tools in read-only mode."""
         tools = get_tools(read_only_mode=True)
         assert len(tools) == len(READ_ONLY_TOOLS)
-        assert len(tools) == 29  # Expected count of read-only tools
+        assert len(tools) == 38  # Expected count of read-only tools
 
     def test_all_tools_mode_tool_count(self):
         """Verify correct number of tools when all write tools are enabled."""
         tools = get_tools(read_only_mode=False)
         assert len(tools) == len(ALL_TOOLS)
-        assert len(tools) == 33  # Expected total count (29 read-only + 4 KV write)
+        assert len(tools) == 42  # Expected total count (38 read-only + 4 KV write)
 
     def test_kv_write_tools_count(self):
         """Verify exactly 4 KV write tools exist."""

--- a/tests/unit/test_xdcr_admin.py
+++ b/tests/unit/test_xdcr_admin.py
@@ -1,0 +1,607 @@
+"""
+Unit tests for the XDCR admin tool bodies (parameter validation,
+argument construction, confirmation gates, and write-scope gating),
+exercised against stubbed REST helpers so no live Couchbase cluster is
+required.
+
+License: MIT - Copyright (c) 2026 Chris Ahrendt
+"""
+
+import json
+from contextlib import contextmanager
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from cb_mcp.tools.xdcr_admin import (
+    _require_write_scope,
+    create_remote_cluster,
+    create_replication,
+    delete_remote_cluster,
+    delete_replication,
+    get_replication_settings,
+    list_remote_clusters,
+    list_replications,
+    pause_replication,
+    resume_replication,
+    update_remote_cluster,
+    update_replication_settings,
+)
+from cb_mcp.utils import xdcr_rest
+from cb_mcp.utils.constants import SCOPE_WRITE
+from cb_mcp.utils.xdcr_rest import (
+    _encode_path_segment,
+    _encoded_replication_id,
+    _form_value,
+    assert_remote_cluster_name,
+    assert_replication_id,
+)
+
+# --------------------------------------------------------------------------
+# Fixtures / helpers
+# --------------------------------------------------------------------------
+
+
+@contextmanager
+def _mock_token(scopes):
+    class _Tok:
+        def __init__(self, scopes_):
+            self.scopes = scopes_
+
+    token = _Tok(scopes) if scopes is not None else None
+    with patch("cb_mcp.tools.xdcr_admin.get_access_token", return_value=token):
+        yield
+
+
+def _ctx():
+    settings = {
+        "connection_string": "couchbase://localhost",
+        "username": "Administrator",
+        "password": "password",
+        "ca_cert_path": None,
+    }
+    lifespan = SimpleNamespace(settings=settings)
+    request = SimpleNamespace(lifespan_context=lifespan)
+    return SimpleNamespace(request_context=request)
+
+
+def _stub_httpx_client():
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.content = b'{"ok":true}'
+    resp.headers = {"content-type": "application/json"}
+    resp.json.return_value = {"ok": True}
+    resp.raise_for_status = MagicMock()
+
+    client = MagicMock()
+    client.get.return_value = resp
+    client.post.return_value = resp
+    client.delete.return_value = resp
+
+    ctx_mgr = MagicMock()
+    ctx_mgr.__enter__.return_value = client
+    ctx_mgr.__exit__.return_value = False
+    return ctx_mgr, client
+
+
+CTX = _ctx()
+
+VALID_ID = "abc123/src-bucket/tgt-bucket"
+
+
+# --------------------------------------------------------------------------
+# assert_remote_cluster_name
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "name",
+    ["my-remote", "cluster_1", "prod.dc2", "A%B", "x" * 100],
+)
+def test_remote_cluster_name_valid(name):
+    assert_remote_cluster_name(name)
+
+
+@pytest.mark.parametrize(
+    "name",
+    ["", "x" * 101, "with/slash", "with space", "with\nnewline", None, 42],
+)
+def test_remote_cluster_name_invalid(name):
+    with pytest.raises(ValueError, match="Invalid remote-cluster name"):
+        assert_remote_cluster_name(name)  # type: ignore[arg-type]
+
+
+# --------------------------------------------------------------------------
+# assert_replication_id
+# --------------------------------------------------------------------------
+
+
+def test_replication_id_valid():
+    assert_replication_id("uuid-1234/src/tgt")
+
+
+def test_replication_id_valid_with_percent():
+    assert_replication_id("uuid-1234/src%bucket/tgt.bucket")
+
+
+@pytest.mark.parametrize(
+    "rid",
+    [
+        "",
+        "no-slashes-at-all",
+        "only/two-segments",
+        "four/segments/here/toomany",
+        "uuid/src/tgt/",
+        "/uuid/src/tgt",
+        "uuid/src bucket/tgt",  # space in segment
+        "uuid/src\nbucket/tgt",  # newline
+    ],
+)
+def test_replication_id_invalid(rid):
+    with pytest.raises(ValueError, match="Invalid replication ID"):
+        assert_replication_id(rid)
+
+
+def test_replication_id_rejects_non_string():
+    with pytest.raises(ValueError, match="Invalid replication ID"):
+        assert_replication_id(None)  # type: ignore[arg-type]
+
+
+# --------------------------------------------------------------------------
+# _encode_path_segment and _encoded_replication_id
+# --------------------------------------------------------------------------
+
+
+def test_encode_path_segment_percent_encoded():
+    assert _encode_path_segment("%2f%2e%2e") == "%252f%252e%252e"
+
+
+def test_encoded_replication_id_preserves_segment_slashes():
+    """Slashes between segments stay; anything inside a segment would be encoded."""
+    result = _encoded_replication_id("uuid1/src-bucket/tgt-bucket")
+    # The slashes between segments are preserved
+    assert result.count("/") == 2
+    # Segment content is passed through since it's already URL-safe
+    assert result == "uuid1/src-bucket/tgt-bucket"
+
+
+def test_encoded_replication_id_encodes_percent_within_segment():
+    result = _encoded_replication_id("uuid1/src%bucket/tgt")
+    # % within a segment gets encoded
+    assert result == "uuid1/src%25bucket/tgt"
+
+
+# --------------------------------------------------------------------------
+# _form_value
+# --------------------------------------------------------------------------
+
+
+def test_form_value_bool():
+    assert _form_value(True) == "true"
+    assert _form_value(False) == "false"
+
+
+def test_form_value_int():
+    assert _form_value(42) == "42"
+
+
+def test_form_value_dict_json_encoded():
+    v = _form_value({"rules": {"src": "tgt"}})
+    assert json.loads(v) == {"rules": {"src": "tgt"}}
+
+
+# --------------------------------------------------------------------------
+# _require_write_scope
+# --------------------------------------------------------------------------
+
+
+def test_write_scope_noop_without_token():
+    with _mock_token(None):
+        _require_write_scope()
+
+
+def test_write_scope_raises_when_missing():
+    with _mock_token(["read"]), pytest.raises(PermissionError, match="write"):
+        _require_write_scope()
+
+
+def test_write_scope_passes_when_present():
+    with _mock_token(["read", SCOPE_WRITE]):
+        _require_write_scope()
+
+
+# --------------------------------------------------------------------------
+# create_remote_cluster
+# --------------------------------------------------------------------------
+
+
+def test_create_remote_cluster_maps_snake_to_camel(monkeypatch):
+    captured = {}
+    monkeypatch.setattr(
+        "cb_mcp.tools.xdcr_admin.create_remote_cluster_rest",
+        lambda **kw: captured.update(kw) or {},
+    )
+    with _mock_token(None):
+        result = create_remote_cluster(
+            CTX,
+            name="my-remote",
+            hostname="couchbases://target.example.com",
+            username="admin",
+            password="secret",
+            demand_encryption=True,
+            encryption_type="full",
+        )
+    form = captured["form"]
+    assert form["name"] == "my-remote"
+    assert form["hostname"] == "couchbases://target.example.com"
+    assert form["demandEncryption"] is True
+    assert form["encryptionType"] == "full"
+    assert result["name"] == "my-remote"
+
+
+def test_create_remote_cluster_rejects_bad_name():
+    with _mock_token(None), pytest.raises(ValueError, match="Invalid remote-cluster"):
+        create_remote_cluster(
+            CTX,
+            name="bad/name",
+            hostname="couchbase://x",
+            username="u",
+            password="p",
+        )
+
+
+def test_create_remote_cluster_extra_forwarded(monkeypatch):
+    captured = {}
+    monkeypatch.setattr(
+        "cb_mcp.tools.xdcr_admin.create_remote_cluster_rest",
+        lambda **kw: captured.update(kw) or {},
+    )
+    with _mock_token(None):
+        create_remote_cluster(
+            CTX,
+            name="r1",
+            hostname="couchbase://x",
+            username="u",
+            password="p",
+            extra={"certificate": "-----BEGIN CERT-----..."},
+        )
+    assert captured["form"]["certificate"].startswith("-----BEGIN CERT")
+
+
+def test_create_remote_cluster_rejects_unknown_extra():
+    with _mock_token(None), pytest.raises(ValueError, match="Unknown XDCR"):
+        create_remote_cluster(
+            CTX,
+            name="r1",
+            hostname="couchbase://x",
+            username="u",
+            password="p",
+            extra={"bogusKey": "x"},
+        )
+
+
+# --------------------------------------------------------------------------
+# update_remote_cluster
+# --------------------------------------------------------------------------
+
+
+def test_update_remote_cluster_requires_a_field():
+    with _mock_token(None), pytest.raises(ValueError, match="at least one"):
+        update_remote_cluster(CTX, name="r1")
+
+
+def test_update_remote_cluster_sends_only_provided_fields(monkeypatch):
+    captured = {}
+    monkeypatch.setattr(
+        "cb_mcp.tools.xdcr_admin.update_remote_cluster_rest",
+        lambda **kw: captured.update(kw) or {},
+    )
+    with _mock_token(None):
+        update_remote_cluster(CTX, name="r1", hostname="couchbase://new-target")
+    assert captured["form"] == {"hostname": "couchbase://new-target"}
+    assert captured["name"] == "r1"
+
+
+# --------------------------------------------------------------------------
+# delete_remote_cluster
+# --------------------------------------------------------------------------
+
+
+def test_delete_remote_cluster_requires_confirm():
+    with _mock_token(None), pytest.raises(ValueError, match="confirm=True"):
+        delete_remote_cluster(CTX, name="r1")
+
+
+def test_delete_remote_cluster_requires_matching_name():
+    with _mock_token(None), pytest.raises(ValueError, match="confirm_name"):
+        delete_remote_cluster(CTX, name="r1", confirm=True, confirm_name="r2")
+
+
+def test_delete_remote_cluster_succeeds(monkeypatch):
+    monkeypatch.setattr(
+        "cb_mcp.tools.xdcr_admin.delete_remote_cluster_rest",
+        lambda **_: {"ok": True},
+    )
+    with _mock_token(None):
+        result = delete_remote_cluster(CTX, name="r1", confirm=True, confirm_name="r1")
+    assert result == {"name": "r1", "deleted": True, "result": {"ok": True}}
+
+
+# --------------------------------------------------------------------------
+# list_remote_clusters
+# --------------------------------------------------------------------------
+
+
+def test_list_remote_clusters(monkeypatch):
+    monkeypatch.setattr(
+        "cb_mcp.tools.xdcr_admin.list_remote_clusters_rest",
+        lambda **_: [{"name": "r1"}, {"name": "r2"}],
+    )
+    result = list_remote_clusters(CTX)
+    assert result == {"remote_clusters": [{"name": "r1"}, {"name": "r2"}]}
+
+
+# --------------------------------------------------------------------------
+# create_replication
+# --------------------------------------------------------------------------
+
+
+def test_create_replication_defaults_continuous(monkeypatch):
+    captured = {}
+    monkeypatch.setattr(
+        "cb_mcp.tools.xdcr_admin.create_replication_rest",
+        lambda **kw: captured.update(kw) or {"id": VALID_ID},
+    )
+    with _mock_token(None):
+        result = create_replication(
+            CTX, from_bucket="src", to_cluster="my-remote", to_bucket="tgt"
+        )
+    assert captured["form"]["replicationType"] == "continuous"
+    assert result["replication_id"] == VALID_ID
+
+
+def test_create_replication_rejects_bad_type():
+    with _mock_token(None), pytest.raises(ValueError, match="continuous"):
+        create_replication(
+            CTX,
+            from_bucket="src",
+            to_cluster="my-remote",
+            to_bucket="tgt",
+            replication_type="bogus",
+        )
+
+
+def test_create_replication_forwards_optional_settings(monkeypatch):
+    captured = {}
+    monkeypatch.setattr(
+        "cb_mcp.tools.xdcr_admin.create_replication_rest",
+        lambda **kw: captured.update(kw) or {},
+    )
+    with _mock_token(None):
+        create_replication(
+            CTX,
+            from_bucket="src",
+            to_cluster="my-remote",
+            to_bucket="tgt",
+            priority="High",
+            compression_type="Snappy",
+        )
+    assert captured["form"]["priority"] == "High"
+    assert captured["form"]["compressionType"] == "Snappy"
+
+
+# --------------------------------------------------------------------------
+# delete_replication
+# --------------------------------------------------------------------------
+
+
+def test_delete_replication_requires_confirm():
+    with _mock_token(None), pytest.raises(ValueError, match="confirm=True"):
+        delete_replication(CTX, replication_id=VALID_ID)
+
+
+def test_delete_replication_requires_matching_name():
+    with _mock_token(None), pytest.raises(ValueError, match="confirm_name"):
+        delete_replication(
+            CTX, replication_id=VALID_ID, confirm=True, confirm_name="wrong"
+        )
+
+
+def test_delete_replication_rejects_bad_id():
+    with _mock_token(None), pytest.raises(ValueError, match="Invalid replication ID"):
+        delete_replication(CTX, replication_id="not-a-valid-id")
+
+
+def test_delete_replication_succeeds(monkeypatch):
+    monkeypatch.setattr(
+        "cb_mcp.tools.xdcr_admin.delete_replication_rest",
+        lambda **_: {"ok": True},
+    )
+    with _mock_token(None):
+        result = delete_replication(
+            CTX, replication_id=VALID_ID, confirm=True, confirm_name=VALID_ID
+        )
+    assert result["deleted"] is True
+    assert result["replication_id"] == VALID_ID
+
+
+# --------------------------------------------------------------------------
+# pause_replication / resume_replication
+# --------------------------------------------------------------------------
+
+
+def test_pause_replication_sends_pause_true(monkeypatch):
+    captured = {}
+    monkeypatch.setattr(
+        "cb_mcp.tools.xdcr_admin.update_replication_settings_rest",
+        lambda **kw: captured.update(kw) or {},
+    )
+    with _mock_token(None):
+        result = pause_replication(CTX, replication_id=VALID_ID)
+    assert captured["form"] == {"pauseRequested": True}
+    assert result["paused"] is True
+
+
+def test_resume_replication_sends_pause_false(monkeypatch):
+    captured = {}
+    monkeypatch.setattr(
+        "cb_mcp.tools.xdcr_admin.update_replication_settings_rest",
+        lambda **kw: captured.update(kw) or {},
+    )
+    with _mock_token(None):
+        result = resume_replication(CTX, replication_id=VALID_ID)
+    assert captured["form"] == {"pauseRequested": False}
+    assert result["resumed"] is True
+
+
+def test_pause_replication_rejects_bad_id():
+    with _mock_token(None), pytest.raises(ValueError, match="Invalid replication ID"):
+        pause_replication(CTX, replication_id="badid")
+
+
+# --------------------------------------------------------------------------
+# list_replications
+# --------------------------------------------------------------------------
+
+
+def test_list_replications(monkeypatch):
+    monkeypatch.setattr(
+        "cb_mcp.tools.xdcr_admin.list_replications_rest",
+        lambda **_: [{"id": VALID_ID, "type": "xdcr"}],
+    )
+    result = list_replications(CTX)
+    assert result == {"replications": [{"id": VALID_ID, "type": "xdcr"}]}
+
+
+# --------------------------------------------------------------------------
+# get_replication_settings
+# --------------------------------------------------------------------------
+
+
+def test_get_replication_settings(monkeypatch):
+    monkeypatch.setattr(
+        "cb_mcp.tools.xdcr_admin.get_replication_settings_rest",
+        lambda **_: {"priority": "High", "pauseRequested": False},
+    )
+    result = get_replication_settings(CTX, replication_id=VALID_ID)
+    assert result == {"priority": "High", "pauseRequested": False}
+
+
+def test_get_replication_settings_rejects_bad_id():
+    with pytest.raises(ValueError, match="Invalid replication ID"):
+        get_replication_settings(CTX, replication_id="badid")
+
+
+# --------------------------------------------------------------------------
+# update_replication_settings
+# --------------------------------------------------------------------------
+
+
+def test_update_replication_settings_requires_a_field():
+    with _mock_token(None), pytest.raises(ValueError, match="at least one"):
+        update_replication_settings(CTX, replication_id=VALID_ID)
+
+
+def test_update_replication_settings_maps_snake_to_camel(monkeypatch):
+    captured = {}
+    monkeypatch.setattr(
+        "cb_mcp.tools.xdcr_admin.update_replication_settings_rest",
+        lambda **kw: captured.update(kw) or {},
+    )
+    with _mock_token(None):
+        update_replication_settings(
+            CTX,
+            replication_id=VALID_ID,
+            priority="Low",
+            checkpoint_interval=600,
+            worker_batch_size=500,
+            collections_migration_mode=True,
+        )
+    form = captured["form"]
+    assert form["priority"] == "Low"
+    assert form["checkpointInterval"] == 600
+    assert form["workerBatchSize"] == 500
+    assert form["collectionsMigrationMode"] is True
+
+
+def test_update_replication_settings_dict_field(monkeypatch):
+    captured = {}
+    monkeypatch.setattr(
+        "cb_mcp.tools.xdcr_admin.update_replication_settings_rest",
+        lambda **kw: captured.update(kw) or {},
+    )
+    with _mock_token(None):
+        update_replication_settings(
+            CTX,
+            replication_id=VALID_ID,
+            collections_mapping_rules={"src.scope1": "tgt.scope2"},
+        )
+    assert captured["form"]["collectionsMappingRules"] == {"src.scope1": "tgt.scope2"}
+
+
+# --------------------------------------------------------------------------
+# REST layer URL construction
+# --------------------------------------------------------------------------
+
+
+def test_delete_remote_cluster_rest_url(monkeypatch):
+    ctx_mgr, client = _stub_httpx_client()
+    monkeypatch.setattr(xdcr_rest.httpx, "Client", lambda **_: ctx_mgr)
+
+    xdcr_rest.delete_remote_cluster_rest(
+        connection_string="couchbase://localhost",
+        username="u",
+        password="p",
+        name="r1",
+    )
+    url = client.delete.call_args.args[0]
+    assert url.endswith("/pools/default/remoteClusters/r1")
+
+
+def test_delete_replication_rest_url(monkeypatch):
+    ctx_mgr, client = _stub_httpx_client()
+    monkeypatch.setattr(xdcr_rest.httpx, "Client", lambda **_: ctx_mgr)
+
+    xdcr_rest.delete_replication_rest(
+        connection_string="couchbase://localhost",
+        username="u",
+        password="p",
+        replication_id=VALID_ID,
+    )
+    url = client.delete.call_args.args[0]
+    assert url.endswith(f"/controller/cancelXDCR/{VALID_ID}")
+
+
+def test_list_replications_rest_filters_to_xdcr(monkeypatch):
+    ctx_mgr, client = _stub_httpx_client()
+    resp = client.get.return_value
+    resp.json.return_value = [
+        {"type": "xdcr", "id": VALID_ID},
+        {"type": "rebalance"},
+        {"type": "xdcr", "id": "other/src/tgt"},
+    ]
+    monkeypatch.setattr(xdcr_rest.httpx, "Client", lambda **_: ctx_mgr)
+
+    result = xdcr_rest.list_replications_rest(
+        connection_string="couchbase://localhost",
+        username="u",
+        password="p",
+    )
+    assert len(result) == 2
+    assert all(r["type"] == "xdcr" for r in result)
+
+
+def test_tls_uses_18091(monkeypatch):
+    ctx_mgr, client = _stub_httpx_client()
+    monkeypatch.setattr(xdcr_rest.httpx, "Client", lambda **_: ctx_mgr)
+
+    xdcr_rest.delete_remote_cluster_rest(
+        connection_string="couchbases://mycluster",
+        username="u",
+        password="p",
+        name="r1",
+    )
+    url = client.delete.call_args.args[0]
+    assert url.startswith("https://")
+    assert ":18091/" in url


### PR DESCRIPTION
> ⚠️ **This PR stacks on top of #187, #195, #196, #197, and #198.** Its diff includes those PRs' code plus this PR's diagnostics code because they are still under review. Once the upstream chain merges, GitHub will auto-shrink this diff to just the 5 new/modified files:
> - `src/cb_mcp/tools/diagnostics.py` (new)
> - `src/cb_mcp/utils/diagnostics_rest.py` (new)
> - `src/cb_mcp/tools/__init__.py` (registration additions + new SENSITIVE_READ_TOOLS category)
> - `tests/unit/test_diagnostics.py` (new, 26 tests)
> - `tests/unit/test_read_only_mode.py` (tool-count updates for the 9 new read tools)
>
> If you'd like to review just the diagnostics changes in isolation, view the diff at: https://github.com/celticht32/mcp-server-couchbase/compare/feat/fts-management-tools...feat/diagnostics-tools

Phase 6 of the phased admin-tool contribution discussed in #157. Introduces a new `SENSITIVE_READ_TOOLS` category — please see the "Open questions" section below for the design decision behind that.

## What this adds

Eleven diagnostic tools that surface the same information the cluster manager Web Console shows, structured for programmatic use by an MCP client. Every tool is a GET; nothing here mutates state.

### Read-only (9 tools) — always available
- `get_cluster_info` — GET `/pools/default`. Full cluster info: nodes, quotas, storage totals, running tasks.
- `get_cluster_stats` — Synthesized summary: `node_count`, `healthy_nodes`, `storage_totals`, `balanced`, `rebalance_status`. A compact view for pollers who don't want to parse the full /pools/default response.
- `get_node_info` — GET `/nodes/self`. Hostname, uptime, memory, services, and OS counters for the current node.
- `get_bucket_stats` — GET `/pools/default/buckets/{bucket}/stats`. Per-bucket ops/sec, disk queues, memory, cache hit ratio.
- `get_index_stats` — GET `/pools/default/buckets/@index/stats`. Index service runtime stats.
- `get_query_stats` — GET `/pools/default/buckets/@query/stats`. Query service runtime stats.
- `get_fts_stats` — GET `/api/nsstats` on FTS ports 8094/18094. Per-index doc counts, query throughput.
- `get_kv_stats` — GET `/pools/default/buckets/{bucket}/stats/curr_items`. KV service current items and related stats (bucket-scoped).
- `get_disk_usage` — Extracted from `/pools/default`'s `storageTotals` block. Returns `{ram, hdd}` summaries at cluster level.

### Sensitive reads (2 tools) — gated behind admin_write_mode
- `get_slow_queries(min_duration_ms=1000, limit=50)` — Reads `system:completed_requests` via SQL++