### PR TITLE
feat: add JIRA issue and pull request templates to guide contributions

### DIFF
--- a/.github/JIRA_ISSUE_TEMPLATE.md
+++ b/.github/JIRA_ISSUE_TEMPLATE.md
@@ -1,0 +1,71 @@
+# MCP Server Issue Template
+
+Copy the template below into the description of your JIRA ticket (Couchbase internal contributors) or GitHub issue (external contributors) when proposing a change to the Couchbase MCP Server. Every pull request must link to an issue based on this template — see [CONTRIBUTING.md](../CONTRIBUTING.md).
+
+For new tools, use **one issue per class of related tools** (e.g., one issue for a set of Search tools), not one issue per tool.
+
+---
+
+## Summary
+
+<!-- One or two sentences describing the proposed change. -->
+
+**Type of change:** New tool(s) / Enhancement / Bug fix / Refactor / Documentation
+
+## Use Case
+
+<!--
+Be as detailed as possible. This is the most important section — it decides
+whether the change is accepted. Cover:
+- What task can an AI agent NOT accomplish with the existing tools today?
+- Who needs this and in what scenario (development, operations, analytics, ...)?
+- A concrete example: the prompt a user would give, and the sequence of tool
+  calls the agent would make to complete it with the proposed tools.
+-->
+
+**Example prompt / workflow:**
+
+> _"Example user prompt to the agent"_
+>
+> 1. Agent calls `proposed_tool_name(param=...)`
+> 2. Agent uses the result to ...
+
+## Proposed Tool Interface(s)
+
+<!-- Repeat this block for each tool in the class. For non-tool changes, describe the interface impact (CLI flags, env vars, config) instead. -->
+
+### `tool_name`
+
+- **Description** (shown to the LLM):
+- **Parameters**: name, type, required/optional, description
+- **Return shape**: fields and types; how large can the result get, and how is its size bounded (e.g., a `limit` parameter, as existing tools use)?
+- **Classification**: `READ_ONLY_TOOLS` or `KV_WRITE_TOOLS` (behavior under read-only mode)
+- **Annotations**: `readOnlyHint` / `idempotentHint` / `destructiveHint`
+- **Confirmation**: does this tool need confirmation/elicitation before executing?
+
+## Feasibility & Deployment
+
+- **Couchbase Python SDK support**: which SDK APIs will be used? If the SDK lacks the capability, describe the REST fallback and why it's needed.
+- **Capella**: available on Capella? Any limitations?
+- **Self-managed Couchbase Server**: available on the server versions supported by the MCP server? Any minimum version or service requirements (Query, Index, Search, ...)?
+- **RBAC**: what permissions does the database user need?
+
+## Compatibility Impact
+
+- **Managed MCP interfaces**: does this touch `cb_mcp.core` contracts (`ClusterProvider`, ...) or require host-specific behavior? (Should normally be "No")
+- **Backwards compatibility**: any changes to existing tool names/parameters/return shapes, CLI flags, or environment variables?
+- **New dependencies**: any new runtime dependencies? (Requires discussion — see CONTRIBUTING.md)
+
+## Testing Plan
+
+- **Unit tests**: what will be covered with fakes/mocks?
+- **Integration tests**: what will be verified against live clusters (both Capella and self-managed)?
+- **Accuracy tests**: for new tools, which tool-calling cases will be added under `tests/accuracy/`?
+
+## Delivery Plan
+
+<!-- How will the work be split into small, reviewable PRs? e.g.,
+1. PR 1: tool skeleton + unit tests for tool A
+2. PR 2: tool B + integration tests
+3. PR 3: accuracy cases + docs
+-->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,50 @@
+<!--
+Thank you for contributing to the Couchbase MCP Server!
+Please read CONTRIBUTING.md before submitting. Keep PRs small and focused —
+one tool, one bug fix, or one refactor per PR.
+-->
+
+## Related Issue
+
+<!-- Every PR must link to an issue (JIRA ticket for Couchbase internal contributors, GitHub issue for external). Required for new tools — the tool interface must be agreed in the issue before implementation. -->
+
+Resolves:
+
+## What does this change do?
+
+## Why is this change needed?
+
+## Evidence of Testing
+
+<!-- PRs without testing evidence will be sent back before review. See "Evidence of testing" in CONTRIBUTING.md. -->
+
+**Automated tests** — commands run and results summary:
+
+```
+# e.g. uv run pytest tests/unit/  →  142 passed
+# e.g. uv run pytest tests/integration/  →  38 passed, 2 skipped
+```
+
+**Environments tested** (both are required):
+
+- [ ] Couchbase Capella (version: ____)
+- [ ] Self-managed Couchbase Server (version: ____, e.g. via Docker)
+
+**Manual verification** — MCP client used (Claude Desktop, Cursor, MCP Inspector, ...) and what was exercised. Screenshots or tool-call transcripts are very helpful:
+
+## Compatibility Considerations
+
+<!-- Note any impact on: Capella vs. self-managed behavior, managed MCP interfaces (cb_mcp.core), existing tool names/parameters/return shapes, CLI flags, environment variables, or new dependencies. Write "None" if not applicable. -->
+
+## Checklist
+
+- [ ] Linked to an issue (required for new tools). The issue can be on JIRA (preferred for internal contributors)/GitHub
+- [ ] Uses the Couchbase SDK (REST fallback justified in the description, if any)
+- [ ] Works on both Capella and self-managed Couchbase Server
+- [ ] No changes to `cb_mcp.core` contracts / managed MCP interfaces (or discussed first)
+- [ ] Unit tests added/updated
+- [ ] Integration tests added/updated (for cluster-touching changes)
+- [ ] Read-only mode and tool annotations handled (for new/changed tools)
+- [ ] Evidence of testing included above
+- [ ] Docs updated (README, DOCKER.md) for user-facing changes
+- [ ] Lint and pre-commit pass

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -38,7 +38,7 @@ Resolves:
 
 ## Checklist
 
-- [ ] Linked to an issue (required for new tools). The issue can be on JIRA (preferred for internal contributors)/GitHub
+- [ ] Linked to an issue (required for new tools). The issue can be on JIRA (preferred for internal contributors) or GitHub.
 - [ ] Uses the Couchbase SDK (REST fallback justified in the description, if any)
 - [ ] Works on both Capella and self-managed Couchbase Server
 - [ ] No changes to `cb_mcp.core` contracts / managed MCP interfaces (or discussed first)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,20 @@
 # Contributing to Couchbase MCP Server
 
-Thank you for your interest in contributing to the Couchbase MCP Server! This guide will help you set up your development environment and understand our development workflow.
+Thank you for your interest in contributing to the Couchbase MCP Server! This guide explains how to set up your development environment, the design principles we expect contributions to follow, and what we look for when reviewing pull requests.
+
+## 📜 Contribution Principles
+
+These are the ground rules we review every contribution against. Reading this section first will save you review round-trips.
+
+1. **Discuss before you build.** Open an issue before writing code for any new tool or significant change — a GitHub issue for external contributors, or a JIRA ticket for Couchbase internal contributors (see the [issue template](.github/JIRA_ISSUE_TEMPLATE.md)). For new tools, we want to design the tool interface (name, parameters, return shape, annotations) together *before* implementation — a tool's interface is a public API for MCP clients and is hard to change later.
+   - Use a **single issue per class of related tools** (e.g., one issue proposing a set of Search tools) rather than one issue per tool.
+   - Explain **why the tools are needed** with as detailed a use case as possible — what an AI agent cannot accomplish today, and how it would use the proposed tools.
+2. **Keep pull requests small and focused.** One tool, one bug fix, or one refactor per PR. Small PRs get reviewed and merged much faster. If your change is large, split it into a series of smaller PRs and mention the plan in the issue.
+3. **Use the Couchbase Python SDK wherever possible.** Prefer the official [Couchbase Python SDK](https://docs.couchbase.com/python-sdk/current/hello-world/start-using-sdk.html) over raw REST calls. Only fall back to REST endpoints when the SDK genuinely does not expose the capability, and call that out explicitly in your PR.
+4. **Support both Capella and self-managed Couchbase Server.** Every feature must work against Couchbase Capella *and* the self-managed Couchbase Server versions supported by this MCP server. Don't rely on APIs, ports, or settings that are unavailable on Capella (e.g., features requiring direct node access) without discussing it in an issue first.
+5. **Don't break the managed MCP interfaces.** The `cb_mcp` package is shared with managed (hosted) MCP server implementations via the host-agnostic contracts in `src/cb_mcp/core/contracts.py` (notably `ClusterProvider`). See [Host-agnostic design](#host-agnostic-design) below.
+6. **Test your changes — and show it.** New code needs unit tests and, where it touches a live cluster, integration tests. PRs must include evidence of testing (see [Evidence of testing](#evidence-of-testing)).
+7. **Preserve backwards compatibility.** Tool names, parameters, return shapes, CLI flags, and environment variables are all public interfaces. Breaking changes need prior discussion in an issue.
 
 ## 🚀 Development Setup
 
@@ -9,6 +23,7 @@ Thank you for your interest in contributing to the Couchbase MCP Server! This gu
 - **Python 3.10+**: Required for the project
 - **[uv](https://docs.astral.sh/uv/)**: Fast Python package installer and dependency manager
 - **Git**: For version control
+- **Couchbase clusters**: a [Capella free tier](https://docs.couchbase.com/cloud/get-started/create-account.html) cluster *and* a self-managed Couchbase Server (e.g., [via Docker](https://docs.couchbase.com/server/current/install/getting-started-docker.html)) — changes must be tested against both
 - **VS Code** (recommended): With Python extension for the best development experience
 
 ### Clone and Setup
@@ -40,8 +55,6 @@ uv run pre-commit run --all-files
 
 We use **[Ruff](https://docs.astral.sh/ruff/)** for fast linting and code formatting to maintain consistent code quality.
 
-### Manual Linting
-
 ```bash
 # Check code quality (no changes made)
 ./scripts/lint.sh
@@ -52,237 +65,235 @@ We use **[Ruff](https://docs.astral.sh/ruff/)** for fast linting and code format
 # or: uv run ruff check src/ --fix && uv run ruff format src/
 ```
 
-### Automatic Linting
-
 - **Pre-commit hooks**: Ruff runs automatically on every `git commit`
-- **VS Code**: Auto-format on save using [Ruff extension](https://marketplace.visualstudio.com/items?itemName=charliermarsh.ruff)
+- **VS Code**: Auto-format on save using the [Ruff extension](https://marketplace.visualstudio.com/items?itemName=charliermarsh.ruff)
 
-### Linting Rules
+### Code Style Guidelines
 
-Our Ruff configuration includes:
+- **Line length**: 88 characters (enforced by Ruff)
+- **Import organization**: isort-style grouping (standard library, third-party, local)
+- **Type hints**: Use modern Python type hints
+- **Docstrings**: Add docstrings for public functions and classes — tool docstrings are shown to LLMs, so make them precise and unambiguous
+- **Error handling**: Catch specific exceptions, log them, and return actionable error messages (tool errors are read by an LLM, which will try to recover based on your message)
+- **Logging**: Use the hierarchical logging pattern `logger = logging.getLogger(f"{MCP_SERVER_NAME}.module.name")`. Never log credentials, connection strings with passwords, or document contents.
 
-- **Code style**: PEP 8 compliance with 88-character line limit
-- **Import organization**: Automatic import sorting and cleanup
-- **Code quality**: Detection of unused variables, simplification opportunities
-- **Modern Python**: Encourages modern Python patterns with `pyupgrade`
+## 🏛️ Design Guidelines
 
-## 📋 Adding New Features
+### Use the SDK first
 
-### Before You Start
+The server is a thin adapter between MCP and the Couchbase Python SDK (`couchbase>=4.4`):
 
-1. **Check existing issues** to see if someone is already working on it
-2. **Open an issue** to discuss larger changes
-3. **Review the codebase** to understand existing patterns
+- Prefer SDK APIs (`Cluster`, `Bucket`, `Scope`, `Collection`, query/index managers) for all cluster operations.
+- If a capability is missing from the SDK, raise it in your proposal issue. A direct REST call may be acceptable as a last resort, but it must work on both Capella and self-managed clusters (including TLS endpoints) and must be flagged in the PR.
 
-### Implementation Guidelines
+### Capella and self-managed support
 
-1. **Follow existing patterns**: Look at similar tools for guidance
-2. **Use the utility modules**: Leverage existing connection and context management
-3. **Add proper logging**: Use the hierarchical logging system
-4. **Handle errors gracefully**: Provide helpful error messages
-5. **Consider read-only mode**: If your tool modifies data, respect `read_only_mode` settings
-6. **Update documentation**: Update README.md, DOCKER.md, and the docs site (in the [couchbase/mcp-server-couchbase-docs](https://github.com/couchbase/mcp-server-couchbase-docs) repo, under `versioned_docs/version-<X>/`) if adding user-facing features
+- Connections must work over both `couchbase://` and `couchbases://` (TLS), including Capella's certificate requirements (handled in `src/cb_mcp/utils/connection.py`).
+- Avoid features that only exist in one deployment model, or gate them gracefully with a clear error message when unavailable.
+- Test against **both** Capella and self-managed Couchbase Server, and state the environments you used in your PR (see [Evidence of testing](#evidence-of-testing)). The [Capella free tier](https://docs.couchbase.com/cloud/get-started/create-account.html) and [Couchbase Server via Docker](https://docs.couchbase.com/server/current/install/getting-started-docker.html) make this easy to do locally.
+
+### Host-agnostic design
+
+The `cb_mcp` package is reused by managed MCP server implementations, not just the standalone CLI in this repo. To keep it portable:
+
+- **Tools must obtain the cluster through the request context / `ClusterProvider`** (`src/cb_mcp/core/contracts.py`) — never from global state, CLI arguments, or environment variables read inside `cb_mcp`.
+- **Don't read CLI/env configuration inside `cb_mcp`.** Configuration parsing belongs to the host (`src/mcp_server.py` and `src/providers/`).
+- **Don't change the `ClusterProvider` protocol** (or other contracts in `core/`) without prior discussion — managed implementations depend on it.
+- Provider configuration returned for status reporting must never include secrets (return `_configured` booleans instead).
+
+### Tool design
+
+New tools are the most common contribution. Before implementing any, open a single issue covering the class of related tools you're proposing, following the [issue template](.github/JIRA_ISSUE_TEMPLATE.md). The issue should include:
+
+- **The use case, in as much detail as possible**: what task an AI agent cannot accomplish with the existing tools, a concrete example prompt/workflow, and how the agent would use the proposed tools to complete it
+- **The proposed interface** for each tool: name, parameters, return shape, and annotations
+- **Deployment considerations**: whether the capability is available on both Capella and self-managed Couchbase Server, and via the SDK
+
+When implementing:
+
+1. **Create the tool function** in the appropriate module under `src/cb_mcp/tools/` (`server.py`, `kv.py`, `query.py`, or `index.py`), or propose a new module in your issue if none fits
+2. **Export the tool** in `src/cb_mcp/tools/__init__.py` and add it to `__all__`
+3. **Add it to the correct tool list** in `src/cb_mcp/tools/__init__.py`: `READ_ONLY_TOOLS` if it only reads data, or `KV_WRITE_TOOLS` if it modifies data (so it's excluded under read-only mode)
+4. **Add an entry to `TOOL_ANNOTATIONS`** with accurate hints (`readOnlyHint`, `idempotentHint`, `destructiveHint`) — clients rely on these for safety decisions
+5. **Respect read-only mode**: any tool that can modify data or cluster state must be excluded when `read_only_mode` is enabled
+6. **Support confirmation**: destructive tools should work with the confirmation/elicitation mechanism (`src/cb_mcp/utils/elicitation.py`)
+7. **Be token-conscious**: tool output goes into an LLM context window. Bound result sizes rather than returning unbounded data — e.g., a `limit` parameter with a sensible default, as existing query tools use
+8. **Write tests** (unit + integration) and verify the tool end-to-end with an MCP client
+
+### Security
+
+- Never log or return credentials, connection strings containing passwords, or certificate contents.
+- Validate and constrain inputs at the tool boundary; remember tool parameters are LLM-generated and may be malformed or adversarial.
+- Query tools must preserve the SQL++ read/write classification (`src/cb_mcp/utils/query_utils.py`) so read-only mode cannot be bypassed.
+- The server makes no network calls other than MCP transport and the configured Couchbase cluster. Don't add telemetry, update checks, or third-party callbacks.
+
+### Dependencies
+
+Keep the dependency footprint small — this server is distributed via PyPI, Docker, and embedded in managed environments.
+
+- Discuss any new runtime dependency in an issue before adding it.
+- Prefer the standard library or existing dependencies (`couchbase`, `fastmcp`, `click`).
+- New dependencies must be permissively licensed and actively maintained.
+
+### Backwards compatibility
+
+Treat all of the following as public API — changes require prior discussion and, usually, a deprecation path:
+
+- Tool names, parameter names/types, and return shapes
+- CLI flags and environment variables
+- The `ClusterProvider` contract and other `cb_mcp.core` interfaces
+- Transport behavior (stdio, Streamable HTTP)
+
+## 🧪 Testing
+
+The test suite is split into three tiers (see [tests/README.md](tests/README.md) for full details):
+
+| Tier | Directory | Requires | Purpose |
+| --- | --- | --- | --- |
+| Unit | `tests/unit/` | Nothing | Pure Python, fakes/mocks, fast and deterministic |
+| Integration | `tests/integration/` | Live Couchbase cluster | Real MCP server over stdio against a real cluster |
+| Accuracy | `tests/accuracy/` | Cluster + `OPENAI_API_KEY` | AI-in-the-loop: does an LLM pick the right tool and get correct answers? |
+
+### What we expect from contributions
+
+- **Unit tests are required** for all new logic — call functions in `cb_mcp.*` directly with fakes.
+- **Integration tests are required** for any tool or change that talks to a cluster. Follow the existing pattern (`create_mcp_session`) and use `pytest.skip` when required env vars are missing.
+- **Test both success and error paths**, plus read-only mode interactions if your tool writes data.
+- **Consider adding accuracy test cases** for new tools (`tests/accuracy/tool_calling/`) so we catch regressions in how LLMs use them.
+- **All existing tests must pass.**
+
+### Running tests
+
+```bash
+# Unit tests (no cluster needed)
+uv run pytest tests/unit/
+
+# Integration tests (needs a live cluster)
+export CB_CONNECTION_STRING="couchbases://..."
+export CB_USERNAME="username"
+export CB_PASSWORD="password"
+export CB_MCP_TEST_BUCKET="travel-sample"
+uv run pytest tests/integration/
+
+# Populate test data / indexes for integration tests
+uv run scripts/setup_test_data.py
+
+# Everything
+uv run pytest
+```
+
+### Evidence of testing
+
+Every PR must describe how the change was tested. Include in the PR description:
+
+- **Test output**: the `pytest` command(s) you ran and a summary of the results
+- **Environment**: confirmation that you tested against both Capella and self-managed Couchbase Server (and the server version, e.g. via Docker)
+- **Manual verification**: which MCP client you used (Claude Desktop, Cursor, MCP Inspector, etc.) and what you exercised — screenshots or transcripts of tool calls are very helpful
+- **Read-only mode**: for write tools, confirmation that the tool is correctly hidden/blocked in read-only mode
+
+PRs without testing evidence will be sent back for it before review.
+
+## 🛠️ Development Workflow
+
+1. **Find or open an issue** describing the change. For new tools, agree on the interface in the issue first.
+2. **Create a branch** for your feature/fix:
+
+   ```bash
+   git checkout -b feature/your-feature-name
+   ```
+
+3. **Make your changes**, following existing patterns and the design guidelines above.
+4. **Run checks locally**:
+
+   ```bash
+   ./scripts/lint.sh
+   uv run pre-commit run --all-files
+   uv run pytest tests/unit/
+   uv run pytest tests/integration/   # with a cluster configured
+   ```
+
+5. **Verify manually** with an MCP client:
+
+   ```bash
+   # Run the server for testing
+   uv run src/mcp_server.py --connection-string "..." --username "..." --password "..."
+
+   # With write operations enabled
+   uv run src/mcp_server.py ... --read-only-mode false
+
+   # With confirmation required for specific tools
+   uv run src/mcp_server.py ... --confirmation-required-tools "delete_document_by_id,replace_document_by_id"
+
+   # With specific tools disabled
+   uv run src/mcp_server.py ... --disabled-tools "upsert_document_by_id,delete_document_by_id"
+   ```
+
+6. **Update documentation** if you changed user-facing behavior: `README.md`, `DOCKER.md`.
+7. **Commit** using descriptive messages (e.g., `feat: add collection stats tool`, `fix: handle missing scope in kv get`). Pre-commit hooks will auto-fix formatting.
+
+## 🤝 Submitting Changes
+
+1. **Push your branch** and create a pull request. If you are working from a fork, follow [these instructions](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request-from-a-fork).
+2. **Keep it small**: if the diff is doing more than one thing, split it.
+3. **Fill in the PR description** — the [PR template](.github/PULL_REQUEST_TEMPLATE.md) is pre-populated when you open a PR:
+   - What does this change do, and which issue does it resolve?
+   - Why is this change needed?
+   - How have you tested it? (see [Evidence of testing](#evidence-of-testing))
+   - Any compatibility considerations (Capella vs. self-managed, managed MCP, tool interface changes)?
+4. **Respond to review feedback** — we aim to review promptly, and small focused PRs get merged fastest.
+
+### PR Checklist
+
+- [ ] Linked to an issue (required for new tools). The issue can be on JIRA (preferred for internal contributors)/GitHub
+- [ ] Uses the Couchbase SDK (REST fallback justified in the description, if any)
+- [ ] Works on both Capella and self-managed Couchbase Server
+- [ ] No changes to `cb_mcp.core` contracts / managed MCP interfaces (or discussed first)
+- [ ] Unit tests added/updated
+- [ ] Integration tests added/updated (for cluster-touching changes)
+- [ ] Read-only mode and tool annotations handled (for new/changed tools)
+- [ ] Evidence of testing included in the PR description
+- [ ] Docs updated (README, DOCKER.md) for user-facing changes
+- [ ] Lint and pre-commit pass
+
+### A note on AI-generated code
+
+We welcome contributions developed with AI assistance — this is an MCP server, after all. However, you are responsible for the code you submit: review and understand every line, verify it actually runs against a real cluster, and don't submit unverified, generated PRs. Testing evidence is required precisely so that "it looks plausible" is never the bar.
 
 ## 🏗️ Project Structure
 
 ```
 mcp-server-couchbase/
 ├── src/
-│   ├── mcp_server.py                              # MCP server entry point (uv run src/mcp_server.py)
-│   ├── providers/                                 # Standalone-host ClusterProvider implementations
-│   │   ├── __init__.py
-│   │   └── static.py                              # StaticClusterProvider used by mcp_server.py
-│   └── cb_mcp/                                    # Reusable Python package shared with other implementations
-│       ├── __init__.py                            # Package marker
-│       ├── tool_registration.py                   # Shared tool preparation for MCP server: parse, filter, wrap with confirmation
-│       ├── core/                                  # Host-agnostic contracts (ClusterProvider, ...)
-│       │   ├── __init__.py
-│       │   └── contracts.py
-│       ├── certs/                                 # SSL/TLS certificates
-│       │   ├── __init__.py                        # Package marker
-│       │   └── capella_root_ca.pem                # Capella root CA certificate (for Capella connections)
-│       ├── tools/                                 # MCP tool implementations
-│       │   ├── __init__.py                        # Tool exports and ALL_TOOLS list
-│       │   ├── server.py                          # Server status and connection tools
-│       │   ├── kv.py                              # Key-value operations (CRUD)
-│       │   ├── query.py                           # SQL++ Query based tools
-│       │   └── index.py                           # Index operations and recommendations
-│       └── utils/                                 # Utility modules
-│           ├── __init__.py                        # Utility exports
-│           ├── constants.py                       # Project constants
-│           ├── config.py                          # Configuration management
-│           ├── connection.py                      # Couchbase connection handling
-│           ├── context.py                         # Application context management
-│           ├── elicitation.py                     # Confirmation/elicitation support
-│           ├── index_utils.py                     # Index-related helper functions
-│           └── query_utils.py                     # Query-related helper functions
-├── scripts/                                       # Development scripts
-│   ├── lint.sh                                    # Manual linting script
-│   ├── lint_fix.sh                                # Auto-fix linting issues
-│   ├── setup_test_data.py                         # Setup script for integration tests
-│   └── update_version.sh                          # Script to bump package version
-├── tests/                                         # Test suite
-│   ├── conftest.py                                # Shared test fixtures
-│   ├── test_confirmation_tools.py                 # Tests for confirmation/elicitation
-│   ├── test_index_tools.py                        # Tests for index tools
-│   ├── test_is_explain_statement.py               # Tests for EXPLAIN detection
-│   ├── test_kv_tools.py                           # Tests for KV operations
-│   ├── test_mcp_integration.py                    # MCP integration tests
-│   ├── test_parse_tool_names.py                   # Tests for tool name parsing
-│   ├── test_performance_tools.py                  # Tests for performance analysis tools
-│   ├── test_query_plan_evaluation.py              # Tests for query plan evaluation
-│   ├── test_query_tools.py                        # Tests for query tools
-│   ├── test_read_only_mode.py                     # Tests for read-only mode
-│   ├── test_server_configuration_status_tool.py   # Tests for server configuration status
-│   ├── test_server_tools.py                       # Tests for server tools
-│   ├── test_tool_registration.py                  # Tests for tool registration
-│   └── test_utils.py                              # Tests for utility functions
-├── .pre-commit-config.yaml                        # Pre-commit hook configuration
-├── build.sh                                       # Docker image build script
-├── Dockerfile                                     # Docker container definition
-├── DOCKER.md                                      # Docker usage documentation
-├── glama.json                                     # Glama MCP catalog metadata
-├── LICENSE                                        # Apache 2.0 license
-├── pyproject.toml                                 # Project dependencies and Ruff config
-├── RELEASE.md                                     # Release process documentation
-├── server.json                                    # MCP Registry configuration
-├── CONTRIBUTING.md                                # Contribution Guide
-└── README.md                                      # Usage
+│   ├── mcp_server.py            # Standalone CLI entry point (uv run src/mcp_server.py)
+│   ├── providers/               # Standalone-host ClusterProvider implementations
+│   │   └── static.py            # StaticClusterProvider (CLI/env config)
+│   └── cb_mcp/                  # Reusable package shared with managed MCP implementations
+│       ├── tool_registration.py # Tool preparation: parse, filter, wrap with confirmation
+│       ├── core/
+│       │   └── contracts.py     # Host-agnostic contracts (ClusterProvider, ...)
+│       ├── certs/               # Bundled Capella root CA certificates
+│       ├── tools/               # MCP tool implementations
+│       │   ├── __init__.py      # Tool exports, tool lists, TOOL_ANNOTATIONS
+│       │   ├── server.py        # Server status and connection tools
+│       │   ├── kv.py            # Key-value operations (CRUD)
+│       │   ├── query.py         # SQL++ query tools
+│       │   └── index.py         # Index operations and recommendations
+│       └── utils/               # Config, connection, context, elicitation, helpers
+├── scripts/                     # Lint, test-data setup, version bump scripts
+├── tests/
+│   ├── unit/                    # Pure Python tests (no cluster)
+│   ├── integration/             # Tests against a live Couchbase cluster
+│   └── accuracy/                # AI-in-the-loop accuracy tests (see tests/README.md)
+├── pyproject.toml               # Dependencies, Ruff and pytest config
+├── Dockerfile / DOCKER.md       # Container build and usage
+├── RELEASE.md                   # Release process
+└── README.md                    # Usage documentation
 ```
-
-## 🛠️ Development Workflow
-
-### Making Changes
-
-1. **Create a branch** for your feature/fix:
-
-   ```bash
-   git checkout -b feature/your-feature-name
-   ```
-
-2. **Make your changes** following the existing patterns
-
-3. **Test your changes**:
-
-   ```bash
-   # Run linting
-   ./scripts/lint.sh
-
-   # Test the MCP server
-   uv run src/mcp_server.py --help
-   ```
-
-4. **Commit your changes**:
-
-   ```bash
-   git add .
-   git commit -m "feat: add your feature description"
-   ```
-
-   The pre-commit hooks will automatically run and fix any formatting issues.
-
-### Adding New Tools
-
-When adding new MCP tools:
-
-1. **Create the tool function** in the appropriate module under `src/cb_mcp/tools/` (`server.py`, `kv.py`, `query.py`, or `index.py`)
-2. **Export the tool** in `src/cb_mcp/tools/__init__.py` and add it to `__all__`
-3. **Add to the correct tool list** in `src/cb_mcp/tools/__init__.py`: `READ_ONLY_TOOLS` if it only reads data, or `KV_WRITE_TOOLS` if it modifies data (so it's excluded under read-only mode)
-4. **Add an entry to `TOOL_ANNOTATIONS`** in the same file with the appropriate hints (`readOnlyHint`, `idempotentHint`, `destructiveHint`)
-5. **Write tests** for the new tool in the `tests/` directory
-6. **Test the tool** with an MCP client
-
-### Code Style Guidelines
-
-- **Line length**: 88 characters (enforced by Ruff)
-- **Import organization**: Use isort-style grouping (standard library, third-party, local)
-- **Type hints**: Use modern Python type hints where helpful
-- **Docstrings**: Add docstrings for public functions and classes
-- **Error handling**: Include appropriate exception handling with logging
-
-## 🧪 Testing
-
-### Manual Testing
-
-Currently, testing is done manually with MCP clients:
-
-1. **Set up environment variables** for your Couchbase cluster
-2. **Run the server** with an MCP client like Claude Desktop
-3. **Test tool functionality** through the client interface
-
-### Automated Tests
-
-Ensure all existing tests pass so your changes don't break anything. The project has a comprehensive test suite in the `tests/` directory:
-
-```bash
-# Run all tests
-uv run pytest
-
-# Run a specific test file
-uv run pytest tests/test_query_tools.py
-
-# Run tests with verbose output
-uv run pytest -v
-```
-
-### Setting Up Test Data
-
-For integration tests that need a running Couchbase cluster:
-
-```bash
-# Set required environment variables
-export CB_CONNECTION_STRING="couchbase://localhost"
-export CB_USERNAME="username"
-export CB_PASSWORD="password"
-export CB_MCP_TEST_BUCKET="travel-sample"
-
-# Run the setup script to create indexes and populate test data
-uv run scripts/setup_test_data.py
-```
-
-### Test Categories
-
-- **Unit tests**: Test individual functions and utilities (e.g., `test_utils.py`, `test_parse_tool_names.py`)
-- **Tool tests**: Test each tool category (e.g., `test_kv_tools.py`, `test_query_tools.py`, `test_index_tools.py`)
-- **Feature tests**: Test specific features like read-only mode (`test_read_only_mode.py`), confirmation tools (`test_confirmation_tools.py`), and query plan evaluation (`test_query_plan_evaluation.py`)
-- **Integration tests**: Test MCP server integration (`test_mcp_integration.py`)
-
-### Writing Tests
-
-When adding new features or tools, add corresponding tests:
-
-1. **Create a test file** in `tests/` following the `test_*.py` naming convention
-2. **Use shared fixtures** from `conftest.py`
-3. **Test both success and error paths**
-4. **Test read-only mode interactions** if your tool performs write operations
-
-## 🤝 Submitting Changes
-
-1. **Run final checks**:
-
-   ```bash
-   # Ensure all linting passes
-   ./scripts/lint.sh
-
-   # Test with pre-commit
-   uv run pre-commit run --all-files
-   ```
-
-2. **Push your branch** and create a pull request (PR)
-
-   If you are working on a forked version of the repo, follow [these instructions](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request-from-a-fork) to create the PR.
-
-3. **Describe your changes** in the PR description:
-   - What does this change do?
-   - Why is this change needed?
-   - How have you tested it?
 
 ## 💡 Tips for Contributors
 
-### Common Development Tasks
-
 ```bash
-# Install new dependencies
+# Install new dependencies (discuss runtime deps in an issue first)
 uv add package-name
 
 # Install new dev dependencies
@@ -290,28 +301,14 @@ uv add --dev package-name
 
 # Update all package dependencies to the latest compatible versions
 uv sync --upgrade
-
-# Update specific package to the latest compatible version
-uv sync --upgrade-package package-name
-
-# Run the server for testing
-uv run src/mcp_server.py --connection-string "..." --username "..." --password "..."
-
-# Run with write operations enabled
-uv run src/mcp_server.py --connection-string "..." --username "..." --password "..." --read-only-mode false
-
-# Run with confirmation required for specific tools
-uv run src/mcp_server.py --connection-string "..." --username "..." --password "..." --confirmation-required-tools "delete_document_by_id,replace_document_by_id"
-
-# Run with specific tools disabled
-uv run src/mcp_server.py --connection-string "..." --username "..." --password "..." --disabled-tools "upsert_document_by_id,delete_document_by_id"
 ```
 
 ### Debugging
 
-- **Use logging**: The project uses hierarchical logging with the pattern `logger = logging.getLogger(f"{MCP_SERVER_NAME}.module.name")`
-- **Check connection**: Ensure your Couchbase cluster is accessible
-- **Validate configuration**: Make sure all required environment variables are set
+- **Use logging**: hierarchical loggers under the `MCP_SERVER_NAME` namespace
+- **Check connection**: ensure your Couchbase cluster is reachable and credentials have the needed RBAC roles
+- **Validate configuration**: make sure required environment variables / CLI flags are set
+- **MCP Inspector**: [`npx @modelcontextprotocol/inspector`](https://modelcontextprotocol.io/docs/tools/inspector) is handy for exercising tools without a full client
 
 ## 📖 Additional Resources
 
@@ -322,8 +319,8 @@ uv run src/mcp_server.py --connection-string "..." --username "..." --password "
 
 ## 🆘 Getting Help
 
-- **Open an issue** for bugs or feature requests
-- **Check existing issues** for similar problems
+- **Open an issue** for bugs, feature requests, or tool proposals
+- **Check existing issues** for similar problems or in-flight work
 - **Review the code** for examples and patterns
 
 Thank you for contributing to the Couchbase MCP Server! 🚀

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -244,7 +244,7 @@ PRs without testing evidence will be sent back for it before review.
 
 ### PR Checklist
 
-- [ ] Linked to an issue (required for new tools). The issue can be on JIRA (preferred for internal contributors)/GitHub
+- [ ] Linked to an issue (required for new tools). The issue can be on JIRA (preferred for internal contributors) or GitHub.
 - [ ] Uses the Couchbase SDK (REST fallback justified in the description, if any)
 - [ ] Works on both Capella and self-managed Couchbase Server
 - [ ] No changes to `cb_mcp.core` contracts / managed MCP interfaces (or discussed first)


### PR DESCRIPTION
This PR improves contributor guidance by expanding CONTRIBUTING.md with clearer design/testing expectations and by adding standardized templates for issues (JIRA/GitHub) and pull requests to encourage small, reviewable contributions.

Changes:

* Expanded CONTRIBUTING.md with contribution principles, design/security/backwards-compatibility guidance, and a more explicit testing/evidence checklist.
* Added a PR template to standardize required context (issue linkage, testing evidence, environments, compatibility considerations).
* Added a reusable issue template intended for copying into JIRA tickets or GitHub issues when proposing changes/new tools.
