### PR TITLE
Fix Read Failure logged at error and name the invalid entried

### DIFF
--- a/src/cb_mcp/utils/config.py
+++ b/src/cb_mcp/utils/config.py
@@ -24,7 +24,7 @@ def get_settings(ctx: Context) -> Mapping[str, Any]:
 def _parse_file(file_path: Path, valid_tool_names: set[str]) -> set[str]:
     """Parse tool names from a file (one tool per line)."""
     tools: set[str] = set()
-    invalid_count = 0
+    invalid: set[str] = set()
     try:
         with open(file_path) as f:
             for raw_line in f:
@@ -34,32 +34,30 @@ def _parse_file(file_path: Path, valid_tool_names: set[str]) -> set[str]:
                 if name in valid_tool_names:
                     tools.add(name)
                 else:
-                    invalid_count += 1
-        if invalid_count > 0:
+                    invalid.add(name)
+        if invalid:
             logger.warning(
-                f"Ignored {invalid_count} invalid tool name(s) from file: {file_path}"
+                f"Ignored invalid tool name(s) from file {file_path}: {sorted(invalid)}"
             )
         logger.debug(f"Loaded {len(tools)} tool name(s) from file: {file_path}")
     except OSError as e:
-        logger.warning(f"Failed to read tool names file {file_path}: {e}")
+        logger.error(f"Failed to read tool names file {file_path.resolve()}: {e}")
     return tools
 
 
 def _parse_comma_separated(value: str, valid_tool_names: set[str]) -> set[str]:
     """Parse comma-separated tool names."""
     tools: set[str] = set()
-    invalid_count = 0
+    invalid: set[str] = set()
     for part in value.split(","):
         name = part.strip()
         if name:
             if name in valid_tool_names:
                 tools.add(name)
             else:
-                invalid_count += 1
-    if invalid_count > 0:
-        logger.warning(
-            f"Ignored {invalid_count} invalid tool name(s) from comma-separated input"
-        )
+                invalid.add(name)
+    if invalid:
+        logger.warning(f"Ignored invalid tool name(s): {sorted(invalid)}")
     logger.debug(f"Parsed tool names from comma-separated string: {tools}")
     return tools
 

--- a/tests/unit/test_parse_tool_names.py
+++ b/tests/unit/test_parse_tool_names.py
@@ -225,6 +225,11 @@ class TestParseDisabledToolsSecurity:
 
         Path(f.name).unlink()
 
+    def test_invalid_tool_names_are_named(self, caplog):
+        """A misspelled tool name must be named so operators can spot it."""
+        parse_tool_names("get_document_by_id,delete_documnt_by_id", VALID_TOOL_NAMES)
+        assert "delete_documnt_by_id" in caplog.text
+
 
 class TestParseDisabledToolsEdgeCases:
     """Tests for edge cases."""


### PR DESCRIPTION
Name the invalid entries — both parse paths now collect an invalid set and log the names
Read failure logged at error with the resolved path 