### PR TITLE
CBSE 23283: Unify kv tools output format

### DIFF
--- a/src/cb_mcp/tools/kv.py
+++ b/src/cb_mcp/tools/kv.py
@@ -19,6 +19,7 @@ from fastmcp import Context
 from ..utils.connection import connect_to_bucket, format_keyspace
 from ..utils.constants import MCP_SERVER_NAME
 from ..utils.context import get_cluster_connection
+from ..utils.responses import tool_error, tool_success
 
 logger = logging.getLogger(f"{MCP_SERVER_NAME}.tools.kv")
 
@@ -54,7 +55,7 @@ def upsert_document_by_id(
     collection_name: str,
     document_id: str,
     document_content: dict[str, Any],
-) -> bool:
+) -> dict[str, Any]:
     """Insert or update a document by its ID.
 
     IMPORTANT: Only use this tool when the user explicitly requests an 'upsert' operation
@@ -62,7 +63,8 @@ def upsert_document_by_id(
 
     DO NOT use this as a fallback when insert_document_by_id or replace_document_by_id fails.
 
-    Returns True on success, False on failure."""
+    Returns {"success": True} on success, or {"success": False, "error": "..."} on
+    failure with the reason (e.g. permission denied, network error, invalid content)."""
     keyspace = format_keyspace(bucket_name, scope_name, collection_name)
     cluster = get_cluster_connection(ctx)
     bucket = connect_to_bucket(cluster, bucket_name)
@@ -71,10 +73,10 @@ def upsert_document_by_id(
         collection = bucket.scope(scope_name).collection(collection_name)
         collection.upsert(document_id, document_content)
         logger.info(f"Successfully upserted document in {keyspace}")
-        return True
+        return tool_success()
     except Exception as e:
         logger.error(f"Error upserting document in {keyspace}: {e}", exc_info=True)
-        return False
+        return tool_error(e)
 
 
 def delete_document_by_id(
@@ -83,9 +85,11 @@ def delete_document_by_id(
     scope_name: str,
     collection_name: str,
     document_id: str,
-) -> bool:
+) -> dict[str, Any]:
     """Delete a document by its ID.
-    Returns True on success, False on failure."""
+
+    Returns {"success": True} on success, or {"success": False, "error": "..."} on
+    failure with the reason (e.g. document not found, permission denied, network error)."""
     keyspace = format_keyspace(bucket_name, scope_name, collection_name)
     cluster = get_cluster_connection(ctx)
     bucket = connect_to_bucket(cluster, bucket_name)
@@ -94,10 +98,10 @@ def delete_document_by_id(
         collection = bucket.scope(scope_name).collection(collection_name)
         collection.remove(document_id)
         logger.info(f"Successfully deleted document from {keyspace}")
-        return True
+        return tool_success()
     except Exception as e:
         logger.error(f"Error deleting document from {keyspace}: {e}", exc_info=True)
-        return False
+        return tool_error(e)
 
 
 def insert_document_by_id(
@@ -107,13 +111,14 @@ def insert_document_by_id(
     collection_name: str,
     document_id: str,
     document_content: dict[str, Any],
-) -> bool:
+) -> dict[str, Any]:
     """Insert a new document by its ID. This operation will FAIL if the document already exists.
 
     IMPORTANT: If this operation fails, DO NOT automatically try replace or upsert.
     Report the failure to the user. They can choose to 'replace' or 'upsert' if desired.
 
-    Returns True on success, False on failure (including if document already exists)."""
+    Returns {"success": True} on success, or {"success": False, "error": "..."} on
+    failure with the reason (e.g. document already exists, permission denied, network error)."""
     keyspace = format_keyspace(bucket_name, scope_name, collection_name)
     cluster = get_cluster_connection(ctx)
     bucket = connect_to_bucket(cluster, bucket_name)
@@ -122,10 +127,10 @@ def insert_document_by_id(
         collection = bucket.scope(scope_name).collection(collection_name)
         collection.insert(document_id, document_content)
         logger.info(f"Successfully inserted document in {keyspace}")
-        return True
+        return tool_success()
     except Exception as e:
         logger.error(f"Error inserting document in {keyspace}: {e}", exc_info=True)
-        return False
+        return tool_error(e)
 
 
 def replace_document_by_id(
@@ -135,13 +140,14 @@ def replace_document_by_id(
     collection_name: str,
     document_id: str,
     document_content: dict[str, Any],
-) -> bool:
+) -> dict[str, Any]:
     """Replace an existing document by its ID. This operation will FAIL if the document does not exist.
 
     IMPORTANT: If this operation fails, DO NOT automatically try insert or upsert.
     Report the failure to the user. They can choose to 'insert' or 'upsert' if desired.
 
-    Returns True on success, False on failure (including if document does not exist)."""
+    Returns {"success": True} on success, or {"success": False, "error": "..."} on
+    failure with the reason (e.g. document does not exist, permission denied, network error)."""
     keyspace = format_keyspace(bucket_name, scope_name, collection_name)
     cluster = get_cluster_connection(ctx)
     bucket = connect_to_bucket(cluster, bucket_name)
@@ -150,10 +156,10 @@ def replace_document_by_id(
         collection = bucket.scope(scope_name).collection(collection_name)
         collection.replace(document_id, document_content)
         logger.info(f"Successfully replaced document in {keyspace}")
-        return True
+        return tool_success()
     except Exception as e:
         logger.error(f"Error replacing document in {keyspace}: {e}", exc_info=True)
-        return False
+        return tool_error(e)
 
 
 def sub_document_lookup_in(

--- a/tests/integration/test_kv_tools.py
+++ b/tests/integration/test_kv_tools.py
@@ -48,8 +48,10 @@ async def test_upsert_document_by_id() -> None:
         )
         payload = extract_payload(response)
 
-        # upsert returns True on success
-        assert payload is True, f"Expected True on upsert success, got {payload}"
+        # upsert returns {"success": True} on success
+        assert payload == {"success": True}, (
+            f"Expected success on upsert, got {payload}"
+        )
 
         # Clean up: delete the test document
         await session.call_tool(
@@ -152,8 +154,10 @@ async def test_delete_document_by_id() -> None:
         )
         payload = extract_payload(response)
 
-        # delete returns True on success
-        assert payload is True, f"Expected True on delete success, got {payload}"
+        # delete returns {"success": True} on success
+        assert payload == {"success": True}, (
+            f"Expected success on delete, got {payload}"
+        )
 
 
 @pytest.mark.asyncio
@@ -244,8 +248,10 @@ async def test_insert_document_by_id() -> None:
         )
         payload = extract_payload(response)
 
-        # insert returns True on success
-        assert payload is True, f"Expected True on insert success, got {payload}"
+        # insert returns {"success": True} on success
+        assert payload == {"success": True}, (
+            f"Expected success on insert, got {payload}"
+        )
 
         # Verify the document was created correctly
         get_response = await session.call_tool(
@@ -309,8 +315,11 @@ async def test_insert_document_fails_if_exists() -> None:
         )
         payload = extract_payload(response)
 
-        # insert returns False when document already exists
-        assert payload is False, "Insert should return False when document exists"
+        # insert returns {"success": False, "error": ...} when document already exists
+        assert payload.get("success") is False, (
+            f"Insert should fail when document exists, got {payload}"
+        )
+        assert "error" in payload
 
         # Clean up
         await session.call_tool(
@@ -361,8 +370,10 @@ async def test_replace_document_by_id() -> None:
         )
         payload = extract_payload(response)
 
-        # replace returns True on success
-        assert payload is True, f"Expected True on replace success, got {payload}"
+        # replace returns {"success": True} on success
+        assert payload == {"success": True}, (
+            f"Expected success on replace, got {payload}"
+        )
 
         # Verify the replacement
         get_response = await session.call_tool(
@@ -415,10 +426,11 @@ async def test_replace_document_fails_if_not_exists() -> None:
         )
         payload = extract_payload(response)
 
-        # replace returns False when document doesn't exist
-        assert payload is False, (
-            "Replace should return False when document doesn't exist"
+        # replace returns {"success": False, "error": ...} when document doesn't exist
+        assert payload.get("success") is False, (
+            f"Replace should fail when document doesn't exist, got {payload}"
         )
+        assert "error" in payload
 
 
 @pytest.mark.asyncio
@@ -476,10 +488,11 @@ async def test_delete_document_fails_if_not_exists() -> None:
         )
         payload = extract_payload(response)
 
-        # delete returns False when document doesn't exist
-        assert payload is False, (
-            "Delete should return False when document doesn't exist"
+        # delete returns {"success": False, "error": ...} when document doesn't exist
+        assert payload.get("success") is False, (
+            f"Delete should fail when document doesn't exist, got {payload}"
         )
+        assert "error" in payload
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_kv_tools_unit.py
+++ b/tests/unit/test_kv_tools_unit.py
@@ -5,7 +5,7 @@ The integration suite covers happy paths and the "document already exists"
 cover the unexpected-SDK-error branches that can't reliably be triggered
 end-to-end:
 
-- upsert_document_by_id returns False on unexpected exception.
+- upsert_document_by_id returns {"success": False, "error": ...} on unexpected exception.
 - insert / replace / delete error branches (parallel coverage).
 """
 
@@ -52,67 +52,71 @@ class TestUpsertDocument:
     """upsert_document_by_id error branch."""
 
     def test_returns_false_on_sdk_error(self) -> None:
-        """An unexpected SDK error must be swallowed and surfaced as False —
-        callers rely on the boolean return rather than exception handling."""
+        """An unexpected SDK error must be swallowed and surfaced with its
+        reason — callers rely on the structured return rather than exception
+        handling."""
         ctx, cluster, collection = _make_ctx_with_collection()
         collection.upsert.side_effect = Exception("transient error")
 
         with patch("cb_mcp.tools.kv.get_cluster_connection", return_value=cluster):
             result = upsert_document_by_id(ctx, "b", "s", "c", "doc1", {"a": 1})
 
-        assert result is False
+        assert result == {"success": False, "error": "transient error"}
         collection.upsert.assert_called_once_with("doc1", {"a": 1})
 
     def test_returns_true_on_success(self) -> None:
-        """Happy path returns True after invoking collection.upsert."""
+        """Happy path returns {"success": True} after invoking collection.upsert."""
         ctx, cluster, _collection = _make_ctx_with_collection()
 
         with patch("cb_mcp.tools.kv.get_cluster_connection", return_value=cluster):
             result = upsert_document_by_id(ctx, "b", "s", "c", "doc1", {"a": 1})
 
-        assert result is True
+        assert result == {"success": True}
 
 
 class TestInsertDocument:
     """insert_document_by_id error branch (parallels upsert)."""
 
     def test_returns_false_on_sdk_error(self) -> None:
-        """Document-exists or any other SDK error must return False."""
+        """Document-exists or any other SDK error must return a failure dict
+        with the reason."""
         ctx, cluster, collection = _make_ctx_with_collection()
         collection.insert.side_effect = Exception("DocumentExistsException")
 
         with patch("cb_mcp.tools.kv.get_cluster_connection", return_value=cluster):
             result = insert_document_by_id(ctx, "b", "s", "c", "doc1", {"a": 1})
 
-        assert result is False
+        assert result == {"success": False, "error": "DocumentExistsException"}
 
 
 class TestReplaceDocument:
     """replace_document_by_id error branch (parallels upsert)."""
 
     def test_returns_false_on_sdk_error(self) -> None:
-        """Document-not-found or any other SDK error must return False."""
+        """Document-not-found or any other SDK error must return a failure
+        dict with the reason."""
         ctx, cluster, collection = _make_ctx_with_collection()
         collection.replace.side_effect = Exception("DocumentNotFoundException")
 
         with patch("cb_mcp.tools.kv.get_cluster_connection", return_value=cluster):
             result = replace_document_by_id(ctx, "b", "s", "c", "doc1", {"a": 1})
 
-        assert result is False
+        assert result == {"success": False, "error": "DocumentNotFoundException"}
 
 
 class TestDeleteDocument:
     """delete_document_by_id error branch (parallels upsert)."""
 
     def test_returns_false_on_sdk_error(self) -> None:
-        """Document-not-found or any other SDK error must return False."""
+        """Document-not-found or any other SDK error must return a failure
+        dict with the reason."""
         ctx, cluster, collection = _make_ctx_with_collection()
         collection.remove.side_effect = Exception("DocumentNotFoundException")
 
         with patch("cb_mcp.tools.kv.get_cluster_connection", return_value=cluster):
             result = delete_document_by_id(ctx, "b", "s", "c", "doc1")
 
-        assert result is False
+        assert result == {"success": False, "error": "DocumentNotFoundException"}
 
 
 class _FakeLookupInResult:


### PR DESCRIPTION
## Related Issue

https://jira.issues.couchbase.com/browse/CBSE-23283

Resolves:

## What does this change do?

Make all the tools have the same output type by using the tool_success and tool_error util functions.

## Why is this change needed?

This change makes the reason of failing of a tool more explicit.

## Evidence of Testing

1. Updated kv tests to accommodate the new output type.

**Automated tests** — commands run and results summary:

```
# uv run pytest tests/unit/  →  469 passed
# uv run pytest tests/integration/  →  101 passed, 13 skipped
# uv run pytest tests/accuracy/  →  92 passed
```

**Environments tested** (both are required):

- [] Couchbase Capella (version: ____)
- [x] Self-managed Couchbase Server (version: ____, e.g. via Docker)

## Checklist

- [x] Linked to an issue (required for new tools). The issue can be on JIRA (preferred for internal contributors) or GitHub.
- [ ] Uses the Couchbase SDK (REST fallback justified in the description, if any)
- [x] Works on both Capella and self-managed Couchbase Server
- [x] No changes to `cb_mcp.core` contracts / managed MCP interfaces (or discussed first)
- [x] Unit tests added/updated
- [x] Integration tests added/updated (for cluster-touching changes)
- [ ] Read-only mode and tool annotations handled (for new/changed tools)
- [x] Evidence of testing included above
- [ ] Docs updated (README, DOCKER.md) for user-facing changes
- [x] Lint and pre-commit pass
