### PR TITLE
Fix: SQL++ identifier injection

### DIFF
--- a/src/cb_mcp/tools/kv.py
+++ b/src/cb_mcp/tools/kv.py
@@ -461,7 +461,7 @@ def sub_document_mutate_in(
                 try:
                     new_value = read_new_value()
                     break
-                except Exception:
+                except Exception:  # noqa: S112 (expected fallback attempt, not a swallowed bug)
                     continue
 
             if new_value is None:

--- a/src/cb_mcp/tools/kv.py
+++ b/src/cb_mcp/tools/kv.py
@@ -461,7 +461,7 @@ def sub_document_mutate_in(
                 try:
                     new_value = read_new_value()
                     break
-                except Exception:  # noqa: S112 (expected fallback attempt, not a swallowed bug)
+                except Exception:
                     continue
 
             if new_value is None:

--- a/src/cb_mcp/tools/query.py
+++ b/src/cb_mcp/tools/query.py
@@ -23,6 +23,11 @@ from ..utils.query_utils import (
 logger = logging.getLogger(f"{MCP_SERVER_NAME}.tools.query")
 
 
+def safe_ident(name: str) -> str:
+    """Backtick-quote a SQL++ identifier, doubling embedded backticks."""
+    return "`" + name.replace("`", "``") + "`"
+
+
 def get_schema_for_collection(
     ctx: Context, bucket_name: str, scope_name: str, collection_name: str
 ) -> dict[str, Any]:
@@ -34,7 +39,7 @@ def get_schema_for_collection(
         logger.debug(
             f"Inferring schema for {format_keyspace(bucket_name, scope_name, collection_name)}"
         )
-        query = f"INFER `{collection_name}`"
+        query = f"INFER {safe_ident(collection_name)}"
         result = run_sql_plus_plus_query(ctx, bucket_name, scope_name, query)
         # Result is a list of list of schemas. We convert it to a list of schemas.
         if result:

--- a/tests/unit/test_query_tools_unit.py
+++ b/tests/unit/test_query_tools_unit.py
@@ -26,6 +26,7 @@ from cb_mcp.tools.query import (
     get_schema_for_collection,
     run_cluster_query,
     run_sql_plus_plus_query,
+    safe_ident,
 )
 
 
@@ -200,6 +201,48 @@ class TestGetSchemaForCollection:
 
         result = get_schema_for_collection(ctx, "b", "s", "users")
         assert result == {"collection_name": "users", "schema": []}
+
+    def test_escapes_embedded_backtick_in_collection_name(self) -> None:
+        """A collection_name containing a backtick must not be able to close
+        the identifier early and inject a second SQL++ statement.
+
+        read_only_mode=False here to isolate query construction from the
+        separate, pre-existing lark_sqlpp INFER-parsing quirk covered by
+        test_infer_with_doubled_backtick_is_unparseable_by_write_guard below.
+        """
+        ctx, _, scope = _make_ctx(read_only_mode=False)
+        scope.query.return_value = iter([])
+        malicious_name = "x`; DELETE FROM `users"
+
+        get_schema_for_collection(ctx, "b", "s", malicious_name)
+
+        query = scope.query.call_args[0][0]
+        assert query == "INFER `x``; DELETE FROM ``users`"
+
+    def test_infer_with_doubled_backtick_is_unparseable_by_write_guard(self) -> None:
+        """Known lark_sqlpp limitation: its INFER grammar rule can't parse a
+        doubled-backtick escaped identifier (unlike its SELECT/FROM rule, which
+        can). Under the default read_only_mode=True, this means a
+        collection_name containing a backtick fails loudly via the write-guard
+        parse step rather than executing — fail-safe, not a security
+        regression, since real Couchbase collection names can't contain
+        backticks anyway."""
+        ctx, _, scope = _make_ctx(read_only_mode=True)
+        scope.query.return_value = iter([])
+        malicious_name = "x`; DELETE FROM `users"
+
+        with pytest.raises(Exception, match="terminal"):
+            get_schema_for_collection(ctx, "b", "s", malicious_name)
+
+
+class TestSafeIdent:
+    """safe_ident: backtick-quoting for SQL++ identifiers."""
+
+    def test_wraps_plain_identifier_in_backticks(self) -> None:
+        assert safe_ident("users") == "`users`"
+
+    def test_doubles_embedded_backticks(self) -> None:
+        assert safe_ident("x`; DELETE FROM `users") == "`x``; DELETE FROM ``users`"
 
 
 class TestRunClusterQuery:


### PR DESCRIPTION
## Related Issue

https://jira.issues.couchbase.com/browse/CBSE-23275

Resolves: CBSE-23275

## What does this change do?

Fixes an unescaped SQL++ identifier injection in `get_schema_for_collection` (`src/cb_mcp/tools/query.py`). The tool built its `INFER` statement by interpolating the caller-supplied `collection_name` directly into a backtick-quoted string (`f"INFER `{collection_name}`"`) with no escaping. A `collection_name` containing a backtick (e.g. `` x`; DELETE FROM `users ``) could close the identifier early and inject a second, executable SQL++ statement.

Adds a `safe_ident()` helper that backtick-quotes an identifier and doubles any embedded backticks (Couchbase's documented escape mechanism for escaped identifiers), and uses it when building the `INFER` query.

## Why is this change needed?

`get_schema_for_collection` is annotated `readOnlyHint=True`, so MCP clients may auto-approve calls to it without confirmation. In a configuration where `CB_MCP_READ_ONLY_MODE=false` and the caller holds a write-scoped token, the injected statement would execute for real — a tool labeled read-only becoming a write primitive. In the default `read_only_mode=true` configuration, the existing write-guard (which parses the query) still catches and blocks the injected write, but the underlying interpolation bug was present regardless of config and is worth closing directly rather than relying solely on the write-guard as the only safety net.

## Evidence of Testing

**Automated tests** — commands run and results summary:

```
uv run pytest tests/unit/  →  482 passed
uv run ruff check .        →  All checks passed
uv run ruff format --check . → 90 files already formatted
```

**Environments tested** (both are required):

- [ ] Couchbase Capella (version: ____)
- [ ] Self-managed Couchbase Server (version: ____, e.g. via

**Manual verification** — Verified via `lark_sqlpp.parse_sqlent()`'s output for a malicious collection name (`` x`; DELETEFROM `users ``) produces a single, non-escaping identifier (`` `x``; DELETE FROM ``users` ``) rather than two statements. Also confirmed against
Couchbase's N1QL identifier documentation that doubling embeer's actual escape mechanism for escaped identifiers.

## Compatibility Considerations

None — this changes only the internal query-string construct_collection`. Tool name, parameters, and return shape areunchanged. No new dependencies.

## Checklist

- [x] Linked to an issue (required for new tools). The issue can be on JIRA (preferred for internal contributors) or GitHub.
- [x] Uses the Couchbase SDK (REST fallback justified in theA, no SDK/REST calls added.
- [ ] Works on both Capella and self-managed Couchbase Server
- [x] No changes to `cb_mcp.core` contracts / managed MCP inst)
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (for cluster-touching s is a pure string-construction fix covered by unit tests against the parser/query-building logic.
- [x] Read-only mode and tool annotations handled (for new/cion change; `get_schema_for_collection` remains correctly`readOnlyHint=True`.
- [x] Evidence of testing included above
- [x] Docs updated (README, DOCKER.md) for user-facing changes — N/A, no user-facing behavior/interface change.
- [x] Lint and pre-commit pass