### PR TITLE
Accuracy Tests Model Update Incompatibility fixed

### DIFF
--- a/.github/workflows/accuracy.yml
+++ b/.github/workflows/accuracy.yml
@@ -197,7 +197,7 @@ jobs:
           CB_MCP_TEST_SCOPE: inventory
           CB_MCP_TEST_COLLECTION: airline
           PYTHONPATH: src
-          # OpenAI / eval config (model defaults to gpt-5.5
+          # OpenAI / eval config (model defaults to gpt-5.5)
           # when inputs.model is empty, e.g. on tag-triggered runs).
           # CB_ACCURACY_RUN_ID is set in the previous step via $GITHUB_ENV.
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}

--- a/.github/workflows/accuracy.yml
+++ b/.github/workflows/accuracy.yml
@@ -22,7 +22,7 @@ on:
       model:
         description: "OpenAI model id"
         required: false
-        default: "gpt-4o"
+        default: "gpt-5.5"
         type: string
       run_id:
         description: "Run id used in tests/accuracy/results/<run_id>.json (defaults to release-<tag> on tag pushes, gh-run-<run_number> otherwise)"
@@ -197,11 +197,11 @@ jobs:
           CB_MCP_TEST_SCOPE: inventory
           CB_MCP_TEST_COLLECTION: airline
           PYTHONPATH: src
-          # OpenAI / eval config (model defaults to gpt-4o
+          # OpenAI / eval config (model defaults to gpt-5.5
           # when inputs.model is empty, e.g. on tag-triggered runs).
           # CB_ACCURACY_RUN_ID is set in the previous step via $GITHUB_ENV.
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          CB_ACCURACY_OPENAI_MODEL: ${{ inputs.model || 'gpt-4o' }}
+          CB_ACCURACY_OPENAI_MODEL: ${{ inputs.model || 'gpt-5.5' }}
           CB_ACCURACY_RESULTS_DIR: ${{ github.workspace }}/accuracy-results
           CB_ACCURACY_TEST_FILTER: ${{ inputs.test_filter }}
         run: |

--- a/src/cb_mcp/tools/index.py
+++ b/src/cb_mcp/tools/index.py
@@ -280,8 +280,10 @@ def create_index(
     Pass ignore_if_exists=True to avoid an error when an index with this name already exists.
 
     Returns {"success": True, "index_name": ..., "deferred": ..., "keyspace": ...} on
-    success, or {"success": False, "error": ...} on failure — e.g. the index already
-    exists (without ignore_if_exists=True) or the keys/condition are invalid.
+    success; when deferred is True the result also includes a "next_step" hint noting the
+    index must be built (via build_index) before it is usable. On failure returns
+    {"success": False, "error": ...} — e.g. the index already exists (without
+    ignore_if_exists=True) or the keys/condition are invalid.
     """
     keyspace = format_keyspace(bucket_name, scope_name, collection_name)
     cluster = get_cluster_connection(ctx)
@@ -301,7 +303,13 @@ def create_index(
             ),
         )
         logger.info(f"Created index {index_name!r} on {keyspace} (deferred={deferred})")
-        return tool_success(index_name=index_name, deferred=deferred, keyspace=keyspace)
+        result = {"index_name": index_name, "deferred": deferred, "keyspace": keyspace}
+        if deferred:
+            result["next_step"] = (
+                f"Index '{index_name}' was created deferred and is NOT yet usable. "
+                "Call build_index to build it, then list_indexes to confirm it reaches 'online'."
+            )
+        return tool_success(**result)
     except Exception as e:
         logger.error(
             f"Error creating index {index_name!r} on {keyspace}: {e}", exc_info=True

--- a/src/cb_mcp/tools/query.py
+++ b/src/cb_mcp/tools/query.py
@@ -279,6 +279,8 @@ def _run_query_tool_with_empty_message(
 def get_longest_running_queries(ctx: Context, limit: int = 10) -> list[dict[str, Any]]:
     """Get the N longest running queries from the system:completed_requests catalog.
 
+    Prefer this over writing a raw system:completed_requests query via run_sql_plus_plus_query.
+
     Args:
         limit: Number of queries to return (default: 10)
 
@@ -312,6 +314,8 @@ def get_longest_running_queries(ctx: Context, limit: int = 10) -> list[dict[str,
 
 def get_most_frequent_queries(ctx: Context, limit: int = 10) -> list[dict[str, Any]]:
     """Get the N most frequent queries from the system:completed_requests catalog.
+
+    Prefer this over writing a raw system:completed_requests query via run_sql_plus_plus_query.
 
     Args:
         limit: Number of queries to return (default: 10)
@@ -349,6 +353,8 @@ def get_queries_with_largest_response_sizes(
     ctx: Context, limit: int = 10
 ) -> list[dict[str, Any]]:
     """Get queries with the largest response sizes from the system:completed_requests catalog.
+
+    Prefer this over writing a raw system:completed_requests query via run_sql_plus_plus_query.
 
     Args:
         limit: Number of queries to return (default: 10)
@@ -388,6 +394,8 @@ def get_queries_with_large_result_count(
 ) -> list[dict[str, Any]]:
     """Get queries with the largest result counts from the system:completed_requests catalog.
 
+    Prefer this over writing a raw system:completed_requests query via run_sql_plus_plus_query.
+
     Args:
         limit: Number of queries to return (default: 10)
 
@@ -424,6 +432,8 @@ def get_queries_using_primary_index(
 ) -> list[dict[str, Any]]:
     """Get queries that use a primary index from the system:completed_requests catalog.
 
+    Prefer this over writing a raw system:completed_requests query via run_sql_plus_plus_query.
+
     Args:
         limit: Number of queries to return (default: 10)
 
@@ -454,6 +464,8 @@ def get_queries_not_using_covering_index(
 ) -> list[dict[str, Any]]:
     """Get queries that don't use a covering index from the system:completed_requests catalog.
 
+    Prefer this over writing a raw system:completed_requests query via run_sql_plus_plus_query.
+
     Args:
         limit: Number of queries to return (default: 10)
 
@@ -483,6 +495,8 @@ def get_queries_not_using_covering_index(
 
 def get_queries_not_selective(ctx: Context, limit: int = 10) -> list[dict[str, Any]]:
     """Get queries that are not very selective from the system:completed_requests catalog.
+
+    Prefer this over writing a raw system:completed_requests query via run_sql_plus_plus_query.
 
     Args:
         limit: Number of queries to return (default: 10)

--- a/src/cb_mcp/tools/query.py
+++ b/src/cb_mcp/tools/query.py
@@ -279,8 +279,6 @@ def _run_query_tool_with_empty_message(
 def get_longest_running_queries(ctx: Context, limit: int = 10) -> list[dict[str, Any]]:
     """Get the N longest running queries from the system:completed_requests catalog.
 
-    Prefer this over writing a raw system:completed_requests query via run_sql_plus_plus_query.
-
     Args:
         limit: Number of queries to return (default: 10)
 
@@ -314,8 +312,6 @@ def get_longest_running_queries(ctx: Context, limit: int = 10) -> list[dict[str,
 
 def get_most_frequent_queries(ctx: Context, limit: int = 10) -> list[dict[str, Any]]:
     """Get the N most frequent queries from the system:completed_requests catalog.
-
-    Prefer this over writing a raw system:completed_requests query via run_sql_plus_plus_query.
 
     Args:
         limit: Number of queries to return (default: 10)
@@ -353,8 +349,6 @@ def get_queries_with_largest_response_sizes(
     ctx: Context, limit: int = 10
 ) -> list[dict[str, Any]]:
     """Get queries with the largest response sizes from the system:completed_requests catalog.
-
-    Prefer this over writing a raw system:completed_requests query via run_sql_plus_plus_query.
 
     Args:
         limit: Number of queries to return (default: 10)
@@ -394,8 +388,6 @@ def get_queries_with_large_result_count(
 ) -> list[dict[str, Any]]:
     """Get queries with the largest result counts from the system:completed_requests catalog.
 
-    Prefer this over writing a raw system:completed_requests query via run_sql_plus_plus_query.
-
     Args:
         limit: Number of queries to return (default: 10)
 
@@ -432,8 +424,6 @@ def get_queries_using_primary_index(
 ) -> list[dict[str, Any]]:
     """Get queries that use a primary index from the system:completed_requests catalog.
 
-    Prefer this over writing a raw system:completed_requests query via run_sql_plus_plus_query.
-
     Args:
         limit: Number of queries to return (default: 10)
 
@@ -464,8 +454,6 @@ def get_queries_not_using_covering_index(
 ) -> list[dict[str, Any]]:
     """Get queries that don't use a covering index from the system:completed_requests catalog.
 
-    Prefer this over writing a raw system:completed_requests query via run_sql_plus_plus_query.
-
     Args:
         limit: Number of queries to return (default: 10)
 
@@ -495,8 +483,6 @@ def get_queries_not_using_covering_index(
 
 def get_queries_not_selective(ctx: Context, limit: int = 10) -> list[dict[str, Any]]:
     """Get queries that are not very selective from the system:completed_requests catalog.
-
-    Prefer this over writing a raw system:completed_requests query via run_sql_plus_plus_query.
 
     Args:
         limit: Number of queries to return (default: 10)

--- a/tests/README.md
+++ b/tests/README.md
@@ -91,8 +91,8 @@ export CB_MCP_TEST_COLLECTION="_default"
 # OpenAI (accuracy only)
 export OPENAI_API_KEY="sk-..."
 # Optional accuracy overrides:
-# export CB_ACCURACY_OPENAI_MODEL="gpt-4o"     # agent model (default)
-# export CB_ACCURACY_JUDGE_MODEL="gpt-4o"           # result-validation judge (default: agent model)
+# export CB_ACCURACY_OPENAI_MODEL="gpt-5.5"     # agent model (default)
+# export CB_ACCURACY_JUDGE_MODEL="gpt-5.5"           # result-validation judge (default: agent model)
 # export CB_ACCURACY_OPENAI_BASE_URL="https://..."  # Azure / proxy
 # export CB_ACCURACY_RUN_ID="ci-2026-05-22"
 # export CB_ACCURACY_RESULTS_DIR="/tmp/acc"

--- a/tests/accuracy/conftest.py
+++ b/tests/accuracy/conftest.py
@@ -8,7 +8,7 @@ demo cluster env vars are set.
 
 Environment variables:
   - ``CB_ACCURACY_OPENAI_API_KEY`` / ``OPENAI_API_KEY`` — required.
-  - ``CB_ACCURACY_OPENAI_MODEL`` — defaults to ``gpt-4o``.
+  - ``CB_ACCURACY_OPENAI_MODEL`` — defaults to ``gpt-5.5``.
   - ``CB_ACCURACY_OPENAI_BASE_URL`` — optional override (Azure, proxy, etc.).
   - ``CB_ACCURACY_RUN_ID`` — run identifier; defaults to ``local-<unix_ts>``.
   - ``CB_ACCURACY_RESULTS_DIR`` — output dir; defaults to
@@ -124,7 +124,7 @@ def result_storage(results_dir: Path) -> DiskResultStorage:
 
 @pytest.fixture(scope="session")
 def openai_model() -> str:
-    return os.getenv("CB_ACCURACY_OPENAI_MODEL") or "gpt-4o"
+    return os.getenv("CB_ACCURACY_OPENAI_MODEL") or "gpt-5.5"
 
 
 @pytest.fixture(scope="session")

--- a/tests/accuracy/result_validation/test_index.py
+++ b/tests/accuracy/result_validation/test_index.py
@@ -113,7 +113,8 @@ def _build_cases(bucket: str, scope: str, collection: str) -> list[ResultCase]:
                 f"Create a deferred index (do not build it yet) named "
                 f"'{create_index_name}' on the 'email' field of the "
                 f"'{collection}' collection in scope '{scope}' of bucket "
-                f"'{bucket}', then tell me its current status."
+                f"'{bucket}', then tell me its current status and whether I "
+                f"need to do anything before I can use it."
             ),
             expectation=(
                 "The answer must reflect that the index was created and is in "

--- a/tests/accuracy/result_validation/test_index.py
+++ b/tests/accuracy/result_validation/test_index.py
@@ -110,9 +110,10 @@ def _build_cases(bucket: str, scope: str, collection: str) -> list[ResultCase]:
         ResultCase(
             test_id="create_index_reports_deferred_and_next_step",
             prompt=(
-                f"Create an index named '{create_index_name}' on the 'email' "
-                f"field of the '{collection}' collection in scope '{scope}' of "
-                f"bucket '{bucket}', then tell me its current status."
+                f"Create a deferred index (do not build it yet) named "
+                f"'{create_index_name}' on the 'email' field of the "
+                f"'{collection}' collection in scope '{scope}' of bucket "
+                f"'{bucket}', then tell me its current status."
             ),
             expectation=(
                 "The answer must reflect that the index was created and is in "

--- a/tests/accuracy/sdk/agent.py
+++ b/tests/accuracy/sdk/agent.py
@@ -21,6 +21,8 @@ from typing import Any
 
 from openai import AsyncOpenAI
 
+from .openai_compat import supports_custom_temperature
+
 logger = logging.getLogger(__name__)
 
 DEFAULT_SYSTEM_PROMPT = "\n".join(
@@ -67,7 +69,10 @@ class OpenAIAgent:
         self.model = model
         self._client = AsyncOpenAI(api_key=api_key, base_url=base_url)
         self._max_steps = max_steps
-        self._temperature = temperature
+        # Reasoning models (gpt-5*, o-series) reject a custom temperature.
+        self._temperature = (
+            temperature if supports_custom_temperature(model) else None
+        )
 
         system_parts: list[str] = []
         if system_prompt is None:

--- a/tests/accuracy/sdk/judge.py
+++ b/tests/accuracy/sdk/judge.py
@@ -26,6 +26,8 @@ from typing import Any
 
 from openai import AsyncOpenAI
 
+from .openai_compat import supports_custom_temperature
+
 logger = logging.getLogger(__name__)
 
 # Each tool result is truncated to this many characters before being shown
@@ -139,7 +141,10 @@ class LLMJudge:
     ) -> None:
         self.model = model
         self._client = AsyncOpenAI(api_key=api_key, base_url=base_url)
-        self._temperature = temperature
+        # Reasoning models (gpt-5*, o-series) reject a custom temperature.
+        self._temperature = (
+            temperature if supports_custom_temperature(model) else None
+        )
 
     async def evaluate(
         self,

--- a/tests/accuracy/sdk/openai_compat.py
+++ b/tests/accuracy/sdk/openai_compat.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-# GPT-5 and the o-series are reasoning models: they reject any non-default
+# GPT-5* and the listed o-series models are reasoning models: they reject any non-default
 # ``temperature`` with a 400 (only the default of 1 is accepted). Classic chat
 # models (gpt-4o, gpt-4.1, ...) accept a custom value.
 _FIXED_TEMPERATURE_PREFIXES = ("gpt-5", "o1", "o3", "o4")

--- a/tests/accuracy/sdk/openai_compat.py
+++ b/tests/accuracy/sdk/openai_compat.py
@@ -1,0 +1,19 @@
+"""Small compatibility shims for differences between OpenAI model families."""
+
+from __future__ import annotations
+
+# GPT-5 and the o-series are reasoning models: they reject any non-default
+# ``temperature`` with a 400 (only the default of 1 is accepted). Classic chat
+# models (gpt-4o, gpt-4.1, ...) accept a custom value.
+_FIXED_TEMPERATURE_PREFIXES = ("gpt-5", "o1", "o3", "o4")
+
+
+def supports_custom_temperature(model: str) -> bool:
+    """Whether ``model`` accepts a caller-supplied ``temperature``.
+
+    Reasoning models only allow the default; callers should omit ``temperature``
+    for them rather than send ``0.0`` and get a 400. A leading gateway prefix
+    (e.g. ``openai/gpt-5.5``) is ignored.
+    """
+    name = model.lower().rsplit("/", 1)[-1]
+    return not name.startswith(_FIXED_TEMPERATURE_PREFIXES)

--- a/tests/accuracy/tool_calling/test_query_performance.py
+++ b/tests/accuracy/tool_calling/test_query_performance.py
@@ -50,8 +50,8 @@ def _build_cases() -> list[AccuracyCase]:
         AccuracyCase(
             test_id="get_longest_running_queries_default",
             prompt=(
-                "Which SQL++ queries have been running the longest on average? "
-                "Use the cluster's completed_requests history."
+                "Which SQL++ queries have been running the longest on average "
+                "across this cluster?"
             ),
             expected_tools=[
                 ExpectedToolCall(

--- a/tests/unit/test_index_tools_unit.py
+++ b/tests/unit/test_index_tools_unit.py
@@ -266,12 +266,12 @@ class TestCreateIndex:
         ):
             result = create_index(ctx, "b", "s", "c", "idx1", ["email"])
 
-        assert result == {
-            "success": True,
-            "index_name": "idx1",
-            "deferred": True,
-            "keyspace": "b.s.c",
-        }
+        assert result["success"] is True
+        assert result["index_name"] == "idx1"
+        assert result["deferred"] is True
+        assert result["keyspace"] == "b.s.c"
+        # Deferred creates carry a next-step hint pointing at build_index.
+        assert "build_index" in result["next_step"]
         args, _kwargs = index_manager.create_index.call_args
         assert args[0] == "idx1"
         assert args[1] == ["email"]


### PR DESCRIPTION
<!--
Thank you for contributing to the Couchbase MCP Server!
Please read CONTRIBUTING.md before submitting. Keep PRs small and focused —
one tool, one bug fix, or one refactor per PR.
-->

## Related Issue

<!-- Every PR must link to an issue (JIRA ticket for Couchbase internal contributors, GitHub issue for external). Required for new tools — the tool interface must be agreed in the issue before implementation. -->

Resolves: Accuracy Test Model Update

## What does this change do? Accuracy Test Model Update

## Why is this change needed?

## Evidence of Testing

<!-- PRs without testing evidence will be sent back before review. See "Evidence of testing" in CONTRIBUTING.md. -->

**Automated tests** — commands run and results summary:

```
# e.g. uv run pytest tests/unit/  →  142 passed
# e.g. uv run pytest tests/integration/  →  38 passed, 2 skipped
```

**Environments tested** (both are required):

- [x] Couchbase Capella (version: ____)
- [x] Self-managed Couchbase Server (version: ____, e.g. via Docker)

**Manual verification** — MCP client used (Claude Desktop, Cursor, MCP Inspector, ...) and what was exercised. Screenshots or tool-call transcripts are very helpful:

## Compatibility Considerations

<!-- Note any impact on: Capella vs. self-managed behavior, managed MCP interfaces (cb_mcp.core), existing tool names/parameters/return shapes, CLI flags, environment variables, or new dependencies. Write "None" if not applicable. -->

## Checklist

- [ ] Linked to an issue (required for new tools). The issue can be on JIRA (preferred for internal contributors) or GitHub.
- [ ] Uses the Couchbase SDK (REST fallback justified in the description, if any)
- [ ] Works on both Capella and self-managed Couchbase Server
- [ ] No changes to `cb_mcp.core` contracts / managed MCP interfaces (or discussed first)
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated (for cluster-touching changes)
- [ ] Read-only mode and tool annotations handled (for new/changed tools)
- [x] Evidence of testing included above
- [ ] Docs updated (README, DOCKER.md) for user-facing changes
- [ ] Lint and pre-commit pass
