### PR TITLE
DA-2041: Add diagnostics tool

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -21,6 +21,7 @@ Documentation: <https://mcp-server.couchbase.com>
 | `get_server_configuration_status` | Get the server status and configuration without connecting to the cluster — reports read-only mode, disabled/confirmation-required tools, OAuth settings, and the resolved logging configuration |
 | `test_cluster_connection` | Check the cluster credentials by connecting to the cluster |
 | `get_cluster_health_and_services` | Get cluster health status and list of all running services |
+| `get_cluster_diagnostics_stats` | Get the SDK's cached connection diagnostics — whether connections were already broken and for how long, without any active network probing |
 
 ### Data model & schema discovery tools
 

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -21,7 +21,7 @@ Documentation: <https://mcp-server.couchbase.com>
 | `get_server_configuration_status` | Get the server status and configuration without connecting to the cluster — reports read-only mode, disabled/confirmation-required tools, OAuth settings, and the resolved logging configuration |
 | `test_cluster_connection` | Check the cluster credentials by connecting to the cluster |
 | `get_cluster_health_and_services` | Get cluster health status and list of all running services |
-| `get_cluster_diagnostics_stats` | Get the SDK's cached connection diagnostics — whether connections were already broken and for how long, without any active network probing |
+| `get_cluster_diagnostics_report` | Get the SDK's cached connection diagnostics — whether connections were already broken and for how long, without any active network probing |
 
 ### Data model & schema discovery tools
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ For full documentation, visit [mcp-server.couchbase.com](https://mcp-server.couc
 | `get_server_configuration_status` | Get the server status and configuration without connecting to the cluster — reports read-only mode, disabled/confirmation-required tools, OAuth settings, and the resolved logging configuration |
 | `test_cluster_connection` | Check the cluster credentials by connecting to the cluster |
 | `get_cluster_health_and_services` | Get cluster health status and list of all running services |
-| `get_cluster_diagnostics_stats` | Get the SDK's cached connection diagnostics — whether connections were already broken and for how long, without any active network probing |
+| `get_cluster_diagnostics_report` | Get the SDK's cached connection diagnostics — whether connections were already broken and for how long, without any active network probing |
 
 ### Data model & schema discovery tools
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ For full documentation, visit [mcp-server.couchbase.com](https://mcp-server.couc
 | `get_server_configuration_status` | Get the server status and configuration without connecting to the cluster — reports read-only mode, disabled/confirmation-required tools, OAuth settings, and the resolved logging configuration |
 | `test_cluster_connection` | Check the cluster credentials by connecting to the cluster |
 | `get_cluster_health_and_services` | Get cluster health status and list of all running services |
+| `get_cluster_diagnostics_stats` | Get the SDK's cached connection diagnostics — whether connections were already broken and for how long, without any active network probing |
 
 ### Data model & schema discovery tools
 

--- a/src/cb_mcp/tools/__init__.py
+++ b/src/cb_mcp/tools/__init__.py
@@ -60,7 +60,7 @@ from .query import (
 # Server tools
 from .server import (
     get_buckets_in_cluster,
-    get_cluster_diagnostics_stats,
+    get_cluster_diagnostics_report,
     get_cluster_health_and_services,
     get_collections_in_scope,
     get_scopes_and_collections_in_bucket,
@@ -79,7 +79,7 @@ READ_ONLY_TOOLS = [
     get_collections_in_scope,
     get_scopes_in_bucket,
     get_cluster_health_and_services,
-    get_cluster_diagnostics_stats,
+    get_cluster_diagnostics_report,
     # KV read tools
     get_document_by_id,
     lookup_subdocument,
@@ -139,7 +139,7 @@ TOOL_ANNOTATIONS: dict[str, ToolAnnotations] = {
     "get_collections_in_scope": ToolAnnotations(readOnlyHint=True),
     "get_scopes_in_bucket": ToolAnnotations(readOnlyHint=True),
     "get_cluster_health_and_services": ToolAnnotations(readOnlyHint=True),
-    "get_cluster_diagnostics_stats": ToolAnnotations(readOnlyHint=True),
+    "get_cluster_diagnostics_report": ToolAnnotations(readOnlyHint=True),
     # KV read tools
     "get_document_by_id": ToolAnnotations(readOnlyHint=True),
     "lookup_subdocument": ToolAnnotations(readOnlyHint=True),
@@ -221,7 +221,7 @@ __all__ = [
     "build_index",
     "drop_index",
     "get_cluster_health_and_services",
-    "get_cluster_diagnostics_stats",
+    "get_cluster_diagnostics_report",
     "get_queries_not_selective",
     "get_queries_not_using_covering_index",
     "get_queries_using_primary_index",

--- a/src/cb_mcp/tools/__init__.py
+++ b/src/cb_mcp/tools/__init__.py
@@ -60,6 +60,7 @@ from .query import (
 # Server tools
 from .server import (
     get_buckets_in_cluster,
+    get_cluster_diagnostics_stats,
     get_cluster_health_and_services,
     get_collections_in_scope,
     get_scopes_and_collections_in_bucket,
@@ -78,6 +79,7 @@ READ_ONLY_TOOLS = [
     get_collections_in_scope,
     get_scopes_in_bucket,
     get_cluster_health_and_services,
+    get_cluster_diagnostics_stats,
     # KV read tools
     get_document_by_id,
     lookup_subdocument,
@@ -137,6 +139,7 @@ TOOL_ANNOTATIONS: dict[str, ToolAnnotations] = {
     "get_collections_in_scope": ToolAnnotations(readOnlyHint=True),
     "get_scopes_in_bucket": ToolAnnotations(readOnlyHint=True),
     "get_cluster_health_and_services": ToolAnnotations(readOnlyHint=True),
+    "get_cluster_diagnostics_stats": ToolAnnotations(readOnlyHint=True),
     # KV read tools
     "get_document_by_id": ToolAnnotations(readOnlyHint=True),
     "lookup_subdocument": ToolAnnotations(readOnlyHint=True),
@@ -218,6 +221,7 @@ __all__ = [
     "build_index",
     "drop_index",
     "get_cluster_health_and_services",
+    "get_cluster_diagnostics_stats",
     "get_queries_not_selective",
     "get_queries_not_using_covering_index",
     "get_queries_using_primary_index",

--- a/src/cb_mcp/tools/server.py
+++ b/src/cb_mcp/tools/server.py
@@ -229,3 +229,45 @@ def get_cluster_health_and_services(
             "error": str(e),
             "message": "Failed to get cluster health and services information",
         }
+
+
+def get_cluster_diagnostics_stats(ctx: Context) -> dict[str, Any]:
+    """Check whether the client's connections were already broken, and for how long.
+
+    Unlike get_cluster_health_and_services (which actively pings each service right now),
+    this reports the SDK's own cached connection state without performing any network I/O.
+    It's cheap enough to call frequently, but it's only as fresh as the last time the SDK
+    actually talked to each node — it won't proactively detect a service that just went down
+    if nothing has touched it since. Use get_cluster_health_and_services instead when you need
+    a live, right-now reachability check; there's also no way to filter this report to specific
+    services the way that tool's ping can, since no I/O means nothing to filter.
+
+    For each known endpoint, reports which service it belongs to, its remote/local addresses,
+    connection state, and last_activity — how long it's been since that connection last saw
+    traffic. Also reports an overall online/degraded/offline cluster state.
+
+    This call makes no request to the server at all, so it needs no specific RBAC role beyond
+    whatever the initial cluster connection already required — unlike an active ping, it isn't
+    gated on KV/Query/Search or Cluster Admin privileges.
+
+    Returns:
+    - Diagnostics report with per-endpoint connection state and overall cluster state
+    """
+    try:
+        cluster = get_cluster_connection(ctx)
+        logger.debug("Retrieving cluster diagnostics")
+        diagnostics_result = cluster.diagnostics()
+        result = diagnostics_result.as_json()
+
+        logger.info("Retrieved cluster diagnostics information")
+        return {
+            "status": "success",
+            "data": json.loads(result),
+        }
+    except Exception as e:
+        logger.error(f"Error getting cluster diagnostics: {e}", exc_info=True)
+        return {
+            "status": "error",
+            "error": str(e),
+            "message": "Failed to get cluster diagnostics information",
+        }

--- a/src/cb_mcp/tools/server.py
+++ b/src/cb_mcp/tools/server.py
@@ -231,7 +231,7 @@ def get_cluster_health_and_services(
         }
 
 
-def get_cluster_diagnostics_stats(ctx: Context) -> dict[str, Any]:
+def get_cluster_diagnostics_report(ctx: Context) -> dict[str, Any]:
     """Check whether the client's connections were already broken, and for how long.
 
     Unlike get_cluster_health_and_services (which actively pings each service right now),

--- a/tests/accuracy/tool_calling/test_server.py
+++ b/tests/accuracy/tool_calling/test_server.py
@@ -8,7 +8,7 @@ Covers:
   - get_collections_in_scope
   - get_scopes_and_collections_in_bucket
   - get_cluster_health_and_services
-  - get_cluster_diagnostics_stats
+  - get_cluster_diagnostics_report
 """
 
 from __future__ import annotations
@@ -179,7 +179,7 @@ def _build_cases(bucket: str, scope: str) -> list[AccuracyCase]:
 
     cases.append(
         AccuracyCase(
-            test_id="get_cluster_diagnostics_stats",
+            test_id="get_cluster_diagnostics_report",
             prompt=(
                 "Without actively pinging anything, check the SDK's own connection "
                 "diagnostics: has any connection already been broken, and if so for "
@@ -187,7 +187,7 @@ def _build_cases(bucket: str, scope: str) -> list[AccuracyCase]:
             ),
             expected_tools=[
                 ExpectedToolCall(
-                    tool_name="get_cluster_diagnostics_stats",
+                    tool_name="get_cluster_diagnostics_report",
                     parameters={},
                 ),
             ],
@@ -241,7 +241,7 @@ SERVER_CASE_IDS = [
     "get_scopes_and_collections_in_bucket",
     "get_cluster_health_and_services_no_bucket",
     "get_cluster_health_and_services_with_bucket",
-    "get_cluster_diagnostics_stats",
+    "get_cluster_diagnostics_report",
     "conversational_what_buckets_do_i_have",
     "conversational_is_everything_healthy",
 ]

--- a/tests/accuracy/tool_calling/test_server.py
+++ b/tests/accuracy/tool_calling/test_server.py
@@ -8,6 +8,7 @@ Covers:
   - get_collections_in_scope
   - get_scopes_and_collections_in_bucket
   - get_cluster_health_and_services
+  - get_cluster_diagnostics_stats
 """
 
 from __future__ import annotations
@@ -178,6 +179,23 @@ def _build_cases(bucket: str, scope: str) -> list[AccuracyCase]:
 
     cases.append(
         AccuracyCase(
+            test_id="get_cluster_diagnostics_stats",
+            prompt=(
+                "Without actively pinging anything, check the SDK's own connection "
+                "diagnostics: has any connection already been broken, and if so for "
+                "how long has it been in that state?"
+            ),
+            expected_tools=[
+                ExpectedToolCall(
+                    tool_name="get_cluster_diagnostics_stats",
+                    parameters={},
+                ),
+            ],
+        )
+    )
+
+    cases.append(
+        AccuracyCase(
             test_id="conversational_what_buckets_do_i_have",
             prompt="What buckets do I actually have on this Couchbase cluster?",
             expected_tools=[
@@ -223,6 +241,7 @@ SERVER_CASE_IDS = [
     "get_scopes_and_collections_in_bucket",
     "get_cluster_health_and_services_no_bucket",
     "get_cluster_health_and_services_with_bucket",
+    "get_cluster_diagnostics_stats",
     "conversational_what_buckets_do_i_have",
     "conversational_is_everything_healthy",
 ]

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -75,7 +75,7 @@ EXPECTED_TOOLS = {
     "build_index",
     "drop_index",
     "get_cluster_health_and_services",
-    "get_cluster_diagnostics_stats",
+    "get_cluster_diagnostics_report",
     # Performance analysis tools
     "get_longest_running_queries",
     "get_most_frequent_queries",
@@ -96,7 +96,7 @@ TOOLS_BY_CATEGORY = {
         "get_scopes_and_collections_in_bucket",
         "get_collections_in_scope",
         "get_cluster_health_and_services",
-        "get_cluster_diagnostics_stats",
+        "get_cluster_diagnostics_report",
     },
     "kv": {
         "get_document_by_id",

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -75,6 +75,7 @@ EXPECTED_TOOLS = {
     "build_index",
     "drop_index",
     "get_cluster_health_and_services",
+    "get_cluster_diagnostics_stats",
     # Performance analysis tools
     "get_longest_running_queries",
     "get_most_frequent_queries",
@@ -95,6 +96,7 @@ TOOLS_BY_CATEGORY = {
         "get_scopes_and_collections_in_bucket",
         "get_collections_in_scope",
         "get_cluster_health_and_services",
+        "get_cluster_diagnostics_stats",
     },
     "kv": {
         "get_document_by_id",

--- a/tests/integration/test_server_tools.py
+++ b/tests/integration/test_server_tools.py
@@ -8,7 +8,7 @@ Tests for:
 - get_scopes_and_collections_in_bucket
 - get_collections_in_scope
 - get_cluster_health_and_services
-- get_cluster_diagnostics_stats
+- get_cluster_diagnostics_report
 - test_cluster_connection
 """
 
@@ -144,11 +144,11 @@ async def test_get_cluster_health_and_services_with_bucket() -> None:
 
 
 @pytest.mark.asyncio
-async def test_get_cluster_diagnostics_stats() -> None:
-    """Verify get_cluster_diagnostics_stats returns the SDK's diagnostics report."""
+async def test_get_cluster_diagnostics_report() -> None:
+    """Verify get_cluster_diagnostics_report returns the SDK's diagnostics report."""
     async with create_mcp_session() as session:
         response = await session.call_tool(
-            "get_cluster_diagnostics_stats", arguments={}
+            "get_cluster_diagnostics_report", arguments={}
         )
         payload = extract_payload(response)
 

--- a/tests/integration/test_server_tools.py
+++ b/tests/integration/test_server_tools.py
@@ -8,6 +8,7 @@ Tests for:
 - get_scopes_and_collections_in_bucket
 - get_collections_in_scope
 - get_cluster_health_and_services
+- get_cluster_diagnostics_stats
 - test_cluster_connection
 """
 
@@ -140,6 +141,20 @@ async def test_get_cluster_health_and_services_with_bucket() -> None:
         assert isinstance(payload, dict), f"Expected dict, got {type(payload)}"
         assert payload.get("status") == "success", f"Expected success status: {payload}"
         assert "data" in payload, "Expected 'data' key with health info"
+
+
+@pytest.mark.asyncio
+async def test_get_cluster_diagnostics_stats() -> None:
+    """Verify get_cluster_diagnostics_stats returns the SDK's diagnostics report."""
+    async with create_mcp_session() as session:
+        response = await session.call_tool(
+            "get_cluster_diagnostics_stats", arguments={}
+        )
+        payload = extract_payload(response)
+
+        assert isinstance(payload, dict), f"Expected dict, got {type(payload)}"
+        assert payload.get("status") == "success", f"Expected success status: {payload}"
+        assert "data" in payload, "Expected 'data' key with diagnostics info"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_read_only_mode.py
+++ b/tests/unit/test_read_only_mode.py
@@ -43,9 +43,9 @@ INDEX_WRITE_TOOL_NAMES = {
     "drop_index",
 }
 
-# Read-only tool names that should always be available (21 tools)
+# Read-only tool names that should always be available (22 tools)
 READ_ONLY_TOOL_NAMES = {
-    # Server/Cluster management tools (7)
+    # Server/Cluster management tools (8)
     "get_buckets_in_cluster",
     "get_server_configuration_status",
     "test_cluster_connection",
@@ -53,6 +53,7 @@ READ_ONLY_TOOL_NAMES = {
     "get_collections_in_scope",
     "get_scopes_in_bucket",
     "get_cluster_health_and_services",
+    "get_cluster_diagnostics_stats",
     # KV read tools (2)
     "get_document_by_id",
     "lookup_subdocument",
@@ -224,15 +225,15 @@ class TestToolCounts:
         """Verify correct number of tools in read-only mode."""
         tools = get_tools(read_only_mode=True)
         assert len(tools) == len(READ_ONLY_TOOLS)
-        assert len(tools) == 21  # Expected count of read-only tools
+        assert len(tools) == 22  # Expected count of read-only tools
 
     def test_all_tools_mode_tool_count(self):
         """Verify correct number of tools when all write tools are enabled."""
         tools = get_tools(read_only_mode=False)
         assert len(tools) == len(ALL_TOOLS)
-        # Expected total count (21 read-only + 5 KV write + 4 collection write
+        # Expected total count (22 read-only + 5 KV write + 4 collection write
         # + 3 index write)
-        assert len(tools) == 33
+        assert len(tools) == 34
 
     def test_kv_write_tools_count(self):
         """Verify exactly 5 KV write tools exist."""

--- a/tests/unit/test_read_only_mode.py
+++ b/tests/unit/test_read_only_mode.py
@@ -53,7 +53,7 @@ READ_ONLY_TOOL_NAMES = {
     "get_collections_in_scope",
     "get_scopes_in_bucket",
     "get_cluster_health_and_services",
-    "get_cluster_diagnostics_stats",
+    "get_cluster_diagnostics_report",
     # KV read tools (2)
     "get_document_by_id",
     "lookup_subdocument",

--- a/tests/unit/test_server_tools_unit.py
+++ b/tests/unit/test_server_tools_unit.py
@@ -8,6 +8,7 @@ reached against a live cluster:
 - get_scopes_and_collections_in_bucket re-raises SDK errors.
 - get_scopes_in_bucket re-raises SDK errors.
 - get_cluster_health_and_services returns an error envelope on ping failure.
+- get_cluster_diagnostics_stats returns an error envelope on diagnostics failure.
 """
 
 from __future__ import annotations
@@ -16,6 +17,7 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 from cb_mcp.tools.server import (
+    get_cluster_diagnostics_stats,
     get_cluster_health_and_services,
     get_scopes_and_collections_in_bucket,
     get_scopes_in_bucket,
@@ -286,3 +288,43 @@ class TestGetClusterHealthAndServices:
         cluster.ping.assert_not_called()
         assert result["status"] == "success"
         assert result["data"] == {"services": {"kv": []}}
+
+
+class TestGetClusterDiagnosticsStats:
+    """get_cluster_diagnostics_stats: error envelope and happy path."""
+
+    def test_returns_error_envelope_on_failure(self) -> None:
+        """A diagnostics failure must be reported as a structured error response."""
+        cluster = MagicMock()
+        cluster.diagnostics.side_effect = Exception("diagnostics failed")
+        ctx = _make_ctx(cluster=cluster)
+
+        with patch(
+            "cb_mcp.tools.server.get_cluster_connection",
+            return_value=cluster,
+        ):
+            result = get_cluster_diagnostics_stats(ctx)
+
+        assert result["status"] == "error"
+        assert "diagnostics failed" in result["error"]
+        assert "Failed to get cluster diagnostics" in result["message"]
+
+    def test_returns_success_envelope_with_diagnostics_data(self) -> None:
+        """Happy path returns the SDK's diagnostics report under 'data'."""
+        cluster = MagicMock()
+        diagnostics_result = MagicMock()
+        diagnostics_result.as_json.return_value = (
+            '{"state": "online", "services": {"kv": []}}'
+        )
+        cluster.diagnostics.return_value = diagnostics_result
+        ctx = _make_ctx(cluster=cluster)
+
+        with patch(
+            "cb_mcp.tools.server.get_cluster_connection",
+            return_value=cluster,
+        ):
+            result = get_cluster_diagnostics_stats(ctx)
+
+        cluster.diagnostics.assert_called_once()
+        assert result["status"] == "success"
+        assert result["data"] == {"state": "online", "services": {"kv": []}}

--- a/tests/unit/test_server_tools_unit.py
+++ b/tests/unit/test_server_tools_unit.py
@@ -8,7 +8,7 @@ reached against a live cluster:
 - get_scopes_and_collections_in_bucket re-raises SDK errors.
 - get_scopes_in_bucket re-raises SDK errors.
 - get_cluster_health_and_services returns an error envelope on ping failure.
-- get_cluster_diagnostics_stats returns an error envelope on diagnostics failure.
+- get_cluster_diagnostics_report returns an error envelope on diagnostics failure.
 """
 
 from __future__ import annotations
@@ -17,7 +17,7 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 from cb_mcp.tools.server import (
-    get_cluster_diagnostics_stats,
+    get_cluster_diagnostics_report,
     get_cluster_health_and_services,
     get_scopes_and_collections_in_bucket,
     get_scopes_in_bucket,
@@ -290,8 +290,8 @@ class TestGetClusterHealthAndServices:
         assert result["data"] == {"services": {"kv": []}}
 
 
-class TestGetClusterDiagnosticsStats:
-    """get_cluster_diagnostics_stats: error envelope and happy path."""
+class TestGetClusterDiagnosticsReport:
+    """get_cluster_diagnostics_report: error envelope and happy path."""
 
     def test_returns_error_envelope_on_failure(self) -> None:
         """A diagnostics failure must be reported as a structured error response."""
@@ -303,7 +303,7 @@ class TestGetClusterDiagnosticsStats:
             "cb_mcp.tools.server.get_cluster_connection",
             return_value=cluster,
         ):
-            result = get_cluster_diagnostics_stats(ctx)
+            result = get_cluster_diagnostics_report(ctx)
 
         assert result["status"] == "error"
         assert "diagnostics failed" in result["error"]
@@ -323,7 +323,7 @@ class TestGetClusterDiagnosticsStats:
             "cb_mcp.tools.server.get_cluster_connection",
             return_value=cluster,
         ):
-            result = get_cluster_diagnostics_stats(ctx)
+            result = get_cluster_diagnostics_report(ctx)
 
         cluster.diagnostics.assert_called_once()
         assert result["status"] == "success"


### PR DESCRIPTION
## Related Issue

https://jira.issues.couchbase.com/browse/DA-2041

## What does this change do?

Add diagnostics tool

## Evidence of Testing

```
uv run pytest tests/unit/                                                  → 490 passed
uv run pytest tests/integration/                                           → 113 passed, 13 skipped (unrelated performance-tool tests, skipped by design)
uv run pytest tests/accuracy/tool_calling/test_server.py -k cluster_health → 4/4 passed, rerun 4x (16/16 total) to check for docstring-change regressions
uv run ruff check / ruff format --check on all touched files              → clean
```

**Environments tested** (both are required):

- [x] Couchbase Capella (version: 8.0.2)
- [x] Self-managed Couchbase Server (version: 8.0.1-4562-enterprise via Docker)

## Checklist

- [x] Linked to an issue (required for new tools). The issue can be on JIRA (preferred for internal contributors) or GitHub.
- [x] Uses the Couchbase SDK (REST fallback justified in the description, if any)
- [x] Works on both Capella and self-managed Couchbase Server
- [x] No changes to `cb_mcp.core` contracts / managed MCP interfaces (or discussed first)
- [x] Unit tests added/updated
- [x] Integration tests added/updated (for cluster-touching changes)
- [x] Read-only mode and tool annotations handled (for new/changed tools)
- [x] Evidence of testing included above
- [x] Docs updated (README, DOCKER.md) for user-facing changes
- [x] Lint and pre-commit pass
